### PR TITLE
Initialize metrics addon agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/stolostron/multicluster-observability-addon
 go 1.20
 
 require (
-	github.com/imdario/mergo v0.3.12
 	github.com/openshift/cluster-logging-operator v0.0.0-20231130135759-9270994dc4bc
 	github.com/operator-framework/api v0.17.7
 	github.com/spf13/cobra v1.8.0
@@ -60,6 +59,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:metrics-addon:agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:metrics-addon:agent
+  rules:
+    - apiGroups: [""]
+      resources:
+        - nodes
+        - nodes/proxy
+        - services
+        - endpoints
+        - pods
+      verbs: ["get", "list", "watch"]
+    - apiGroups:
+        - extensions
+      resources:
+        - ingresses
+      verbs: ["get", "list", "watch"]
+    - nonResourceURLs: ["/federate"]
+      verbs: ["get"]
+subjects:
+  - kind: ServiceAccount
+    name: metrics-addon-sa
+    namespace: { { .AddonInstallNamespace } }

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -26,3 +27,4 @@ subjects:
   - kind: ServiceAccount
     name: metrics-addon-sa
     namespace: { { .AddonInstallNamespace } }
+{{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -1,0 +1,103 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus-agent-conf
+  namespace: {{ .AddonInstallNamespace }}
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/component: metrics-agent
+    app.kubernetes.io/instance: metrics-agent
+    app.kubernetes.io/name: prometheus-agent-conf
+    app.kubernetes.io/version: 2.48.1
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+
+    scrape_configs:
+      - job_name: 'federate'
+        scrape_interval: 4m
+
+        honor_labels: true
+        metrics_path: '/federate'
+
+        tls_config:
+          ca_file: /etc/serving-certs-ca-bundle/service-ca.crt
+          cert_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          key_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        params:
+          'match[]':
+            - {__name__="up"}
+            - {__name__=":node_memory_MemAvailable_bytes:sum"}
+            - {__name__="cluster:capacity_cpu_cores:sum"}
+            - {__name__="cluster:capacity_memory_bytes:sum"}
+            - {__name__="cluster:container_cpu_usage:ratio"}
+            - {__name__="cluster:container_spec_cpu_shares:ratio"}
+            - {__name__="cluster:cpu_usage_cores:sum"}
+            - {__name__="cluster:memory_usage:ratio"}
+            - {__name__="cluster:memory_usage_bytes:sum"}
+            - {__name__="cluster:usage:resources:sum"}
+            - {__name__="cluster_infrastructure_provider"}
+            - {__name__="cluster_version"}
+            - {__name__="cluster_version_payload"}
+            - {__name__="container_cpu_cfs_throttled_periods_total"}
+            - {__name__="container_memory_cache"}
+            - {__name__="container_memory_rss"}
+            - {__name__="container_memory_swap"}
+            - {__name__="container_memory_working_set_bytes"}
+            - {__name__="container_network_receive_bytes_total"}
+            - {__name__="container_network_receive_packets_dropped_total"}
+            - {__name__="container_network_receive_packets_total"}
+            - {__name__="container_network_transmit_bytes_total"}
+            - {__name__="container_network_transmit_packets_dropped_total"}
+            - {__name__="container_network_transmit_packets_total"}
+            - {__name__="haproxy_backend_connections_total"}
+            - {__name__="instance:node_cpu_utilisation:rate1m"}
+            - {__name__="instance:node_load1_per_cpu:ratio"}
+            - {__name__="instance:node_memory_utilisation:ratio"}
+            - {__name__="instance:node_network_receive_bytes_excluding_lo:rate1m"}
+            - {__name__="instance:node_network_receive_drop_excluding_lo:rate1m",}
+            - {__name__="instance:node_network_transmit_bytes_excluding_lo:rate1m"}
+            - {__name__="instance:node_network_transmit_drop_excluding_lo:rate1m"}
+            - {__name__="instance:node_num_cpu:sum"}
+            - {__name__="instance:node_vmstat_pgmajfault:rate1m"}
+            - {__name__="instance_device:node_disk_io_time_seconds:rate1m"}
+            - {__name__="instance_device:node_disk_io_time_weighted_seconds:rate1m"}
+            - {__name__="kube_node_status_allocatable_cpu_cores"}
+            - {__name__="kube_node_status_allocatable_memory_bytes"}
+            - {__name__="kube_pod_container_resource_limits_cpu_cores"}
+            - {__name__="kube_pod_container_resource_limits_memory_bytes"}
+            - {__name__="kube_pod_container_resource_requests_cpu_cores"}
+            - {__name__="kube_pod_container_resource_requests_memory_bytes"}
+            - {__name__="kube_pod_info"}
+            - {__name__="kube_resourcequota"}
+            - {__name__="machine_cpu_cores"}
+            - {__name__="machine_memory_bytes"}
+            - {__name__="mixin_pod_workload"}
+            - {__name__="node_cpu_seconds_total"}
+            - {__name__="node_filesystem_avail_bytes"}
+            - {__name__="node_filesystem_size_bytes"}
+            - {__name__="node./oc _memory_MemAvailable_bytes"}
+            - {__name__="node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate"}
+            - {__name__="node_namespace_pod_container:container_memory_cache"}
+            - {__name__="node_namespace_pod_container:container_memory_rss"}
+            - {__name__="node_namespace_pod_container:container_memory_swap"}
+            - {__name__="node_namespace_pod_container:container_memory_working_set_bytes"}
+            - {__name__="node_netstat_Tcp_OutSegs"}
+            - {__name__="node_netstat_Tcp_RetransSegs"}
+            - {__name__="node_netstat_TcpExt_TCPSynRetrans"}
+
+        static_configs:
+          - targets:
+            - 'http://prometheus-k8s.openshift-monitoring.svc.cluster.local:9092'
+
+    remote_write:
+    - url: 'https://observability-observatorium-observatorium-api.open-cluster-management-observability.svc.cluster.local:8443/api/metrics/v1/test-mtls/api/v1/receive'
+      metadata_config:
+        send: false
+      tls_config:
+        ca_file: /tlscerts/ca/ca.crt
+        cert_file: /tlscerts/certs/tls.crt
+        key_file: /tlscerts/certs/tls.key

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-agent-conf
-  namespace: {{ .AddonInstallNamespace }}
+  namespace: {{ .Value.addonInstallNamespace }}
   labels:
     app.kubernetes.io/part-of: multicluster-observability-addon
     app.kubernetes.io/component: metrics-agent
@@ -101,3 +102,4 @@ data:
         ca_file: /tlscerts/ca/ca.crt
         cert_file: /tlscerts/certs/tls.crt
         key_file: /tlscerts/certs/tls.key
+{{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: metrics-addon-agent
-  namespace: {{ .AddonInstallNamespace }}
+  namespace: {{ .Value.addonInstallNamespace }}
   labels:
     app.kubernetes.io/part-of: multicluster-observability-addon
     app.kubernetes.io/component: metrics-agent
@@ -84,3 +85,4 @@ spec:
     rollingUpdate:
       maxUnavailable: 25%
       maxSurge: 25%
+{{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -1,0 +1,86 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: metrics-addon-agent
+  namespace: {{ .AddonInstallNamespace }}
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/component: metrics-agent
+    app.kubernetes.io/instance: metrics-agent
+    app.kubernetes.io/name: metrics-addon-agent
+    app.kubernetes.io/version: 2.48.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: multicluster-observability-addon
+      app.kubernetes.io/component: metrics-agent
+      app.kubernetes.io/instance: metrics-agent
+      app.kubernetes.io/name: metrics-addon-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: multicluster-observability-addon
+        app.kubernetes.io/component: metrics-agent
+        app.kubernetes.io/instance: metrics-agent
+        app.kubernetes.io/name: metrics-addon-agent
+    spec:
+      serviceAccountName: metrics-addon-sa
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-agent-conf
+            defaultMode: 420
+        - name: prometheus-storage-volume
+          emptyDir: {}
+        - name: serving-certs-ca-bundle
+          configMap:
+            name: client-serving-certs-ca-bundle
+        - name: observability-managed-cluster-certs
+          secret:
+            secretName: observability-managed-cluster-certs
+      containers:
+        - name: prometheus-agent
+          ports:
+            - containerPort: 9090
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 500M
+            limits:
+              cpu: 1
+              memory: 1Gi
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+            - name: observability-managed-cluster-certs
+              readOnly: true
+              mountPath: /tlscerts/certs
+            - name: observability-managed-cluster-certs
+              readOnly: true
+              mountPath: /tlscerts/ca
+            - name: serving-certs-ca-bundle
+              mountPath: /etc/serving-certs-ca-bundle
+              readOnly: false
+          image: "quay.io/prometheus/prometheus:v2.48.1"
+          args:
+            - "--log.level=debug"
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
+            - "--web.enable-lifecycle"
+            - "--enable-feature=agent"
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: metrics-addon-sa
+  namespace: {{ .AddonInstallNamespace }}
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/component: metrics-agent
+    app.kubernetes.io/instance: metrics-agent
+    app.kubernetes.io/name: metrics-addon-sa

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -1,10 +1,12 @@
+{{- if .Values.enabled }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: metrics-addon-sa
-  namespace: {{ .AddonInstallNamespace }}
+  namespace: {{ .Value.addonInstallNamespace }}
   labels:
     app.kubernetes.io/part-of: multicluster-observability-addon
     app.kubernetes.io/component: metrics-agent
     app.kubernetes.io/instance: metrics-agent
     app.kubernetes.io/name: metrics-addon-sa
+{{- end }}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,12 +10,10 @@ type MetricsValues struct {
 	Enabled bool `json:"enabled"`
 }
 
-func GetValuesFunc(k8s client.Client, cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) (MetricsValues, error) {
+func GetValuesFunc(_ client.Client, _ *clusterv1.ManagedCluster, _ *addonapiv1alpha1.ManagedClusterAddOn) (MetricsValues, error) {
 	values := MetricsValues{
 		Enabled: false,
 	}
-
-	// Get necessary values
 
 	values.Enabled = true
 	return values, nil


### PR DESCRIPTION
This commit initializes a metrics addon agent which is actually a Prometheus Agent deployment, that federates metrics from openshift-monitoring Prometheus and remote-writes them to ACM Hub Thanos.

In general, we do not expect end user to modify this configuration in any way as we only plan to offer a single metrics sink of ACM Thanos.

Still quite new to addons, so would appreciate any early feedback, and if I'm doing the correct thing here. :)

TODOs: Add tests, actually run this on a cluster and add facilities for rules and collectrules to fully replace metrics-collector