### PR TITLE
logging: adds requirement for common resources to have signal label 

### DIFF
--- a/internal/addon/helm/values.go
+++ b/internal/addon/helm/values.go
@@ -72,7 +72,7 @@ func GetValuesFunc(k8s client.Client) addonfactory.GetValuesFunc {
 }
 
 func getAddOnDeploymentConfig(k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAddOn) (*addonapiv1alpha1.AddOnDeploymentConfig, error) {
-	key := addon.GetObjectKey(mcAddon.Status.ConfigReferences, addonutils.AddOnDeploymentConfigGVR.Group, "addondeploymentconfigs")
+	key := addon.GetObjectKey(mcAddon.Status.ConfigReferences, addonutils.AddOnDeploymentConfigGVR.Group, addon.AddonDeploymentConfigResource)
 	addOnDeployment := &addonapiv1alpha1.AddOnDeploymentConfig{}
 	if err := k8s.Get(context.TODO(), key, addOnDeployment, &client.GetOptions{}); err != nil {
 		// TODO(JoaoBraveCoding) Add proper error handling
@@ -92,21 +92,21 @@ func buildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 	}
 
 	for _, keyvalue := range addOnDeployment.Spec.CustomizedVariables {
-		if keyvalue.Name == "metricsDisabled" {
+		if keyvalue.Name == addon.AdcMetricsDisabledKey {
 			value, err := strconv.ParseBool(keyvalue.Value)
 			if err != nil {
 				return opts, err
 			}
 			opts.MetricsDisabled = value
 		}
-		if keyvalue.Name == "loggingDisabled" {
+		if keyvalue.Name == addon.AdcLoggingDisabledKey {
 			value, err := strconv.ParseBool(keyvalue.Value)
 			if err != nil {
 				return opts, err
 			}
 			opts.LoggingDisabled = value
 		}
-		if keyvalue.Name == "tracingDisabled" {
+		if keyvalue.Name == addon.AdcTracingisabledKey {
 			value, err := strconv.ParseBool(keyvalue.Value)
 			if err != nil {
 				return opts, err

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -1,0 +1,93 @@
+package helm
+
+import (
+	"testing"
+
+	loggingapis "github.com/openshift/cluster-logging-operator/apis"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/rhobs/multicluster-observability-addon/internal/addon"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
+	"open-cluster-management.io/addon-framework/pkg/agent"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	_ = loggingapis.AddToScheme(scheme.Scheme)
+	_ = operatorsv1.AddToScheme(scheme.Scheme)
+	_ = operatorsv1alpha1.AddToScheme(scheme.Scheme)
+	_ = addonapiv1alpha1.AddToScheme(scheme.Scheme)
+)
+
+func Test_Mcoa_Disable_Charts(t *testing.T) {
+	var (
+		managedCluster        *clusterv1.ManagedCluster
+		managedClusterAddOn   *addonapiv1alpha1.ManagedClusterAddOn
+		addOnDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig
+	)
+
+	managedCluster = addontesting.NewManagedCluster("cluster-1")
+	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
+
+	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "addon.open-cluster-management.io",
+				Resource: "addondeploymentconfigs",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: "open-cluster-management",
+				Name:      "multicluster-observability-addon",
+			},
+		},
+	}
+
+	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multicluster-observability-addon",
+			Namespace: "open-cluster-management",
+		},
+		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
+			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+				{
+					Name:  "metricsDisabled",
+					Value: "true",
+				},
+				{
+					Name:  "loggingDisabled",
+					Value: "true",
+				},
+				{
+					Name:  "tracingDisabled",
+					Value: "true",
+				},
+			},
+		},
+	}
+
+	fakeKubeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(addOnDeploymentConfig).
+		Build()
+
+	loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, addon.McoaChartDir).
+		WithGetValuesFuncs(GetValuesFunc(fakeKubeClient)).
+		WithAgentRegistrationOption(&agent.RegistrationOption{}).
+		WithScheme(scheme.Scheme).
+		BuildHelmAgentAddon()
+	if err != nil {
+		klog.Fatalf("failed to build agent %v", err)
+	}
+
+	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(objects))
+}

--- a/internal/addon/var.go
+++ b/internal/addon/var.go
@@ -18,6 +18,11 @@ const (
 	AdcMetricsDisabledKey = "metricsDisabled"
 	AdcLoggingDisabledKey = "loggingDisabled"
 	AdcTracingisabledKey  = "tracingDisabled"
+
+	SignalLabelKey = "mcoa.openshift.io/signal"
+	SignalMetrics  = "metrics"
+	SignalLogging  = "logging"
+	SignalTracing  = "tracing"
 )
 
 //go:embed manifests

--- a/internal/addon/var.go
+++ b/internal/addon/var.go
@@ -6,12 +6,18 @@ const (
 	Name             = "multicluster-observability-addon"
 	InstallNamespace = "open-cluster-management"
 
+	McoaChartDir    = "manifests/charts/mcoa"
 	MetricsChartDir = "manifests/charts/mcoa/charts/metrics"
 	LoggingChartDir = "manifests/charts/mcoa/charts/logging"
 	TracingChartDir = "manifests/charts/mcoa/charts/tracing"
 
-	ConfigMapResource = "configmaps"
-	SecretResource    = "secrets"
+	ConfigMapResource             = "configmaps"
+	SecretResource                = "secrets"
+	AddonDeploymentConfigResource = "addondeploymentconfigs"
+
+	AdcMetricsDisabledKey = "metricsDisabled"
+	AdcLoggingDisabledKey = "loggingDisabled"
+	AdcTracingisabledKey  = "tracingDisabled"
 )
 
 //go:embed manifests

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,57 +2,29 @@ package logging
 
 import (
 	"context"
-	"encoding/json"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/rhobs/multicluster-observability-addon/internal/addon"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetValuesFunc(k8s client.Client, cluster *clusterv1.ManagedCluster, mcAddon *addonapiv1alpha1.ManagedClusterAddOn, adoc *addonapiv1alpha1.AddOnDeploymentConfig) (LoggingValues, error) {
-	values := LoggingValues{
-		Enabled: true,
-	}
-
-	channel, err := getSubscriptionChannel(adoc)
-	if err != nil {
-		return values, err
-	}
-	values.LoggingSubscriptionChannel = channel
-
-	clfSpec, err := getClusterLogForwarderSpec(k8s, cluster, mcAddon)
-	if err != nil {
-		return values, err
-	}
-
-	b, err := json.Marshal(clfSpec)
-	if err != nil {
-		return values, err
-	}
-
-	values.CLFSpec = string(b)
-
-	return values, nil
-}
-
-func getSubscriptionChannel(adoc *addonapiv1alpha1.AddOnDeploymentConfig) (string, error) {
+func buildSubscriptionChannel(adoc *addonapiv1alpha1.AddOnDeploymentConfig) string {
 	if adoc == nil || len(adoc.Spec.CustomizedVariables) == 0 {
-		return defaultLoggingVersion, nil
+		return defaultLoggingVersion
 	}
 
 	for _, keyvalue := range adoc.Spec.CustomizedVariables {
 		if keyvalue.Name == subscriptionChannelValueKey {
-			return keyvalue.Value, nil
+			return keyvalue.Value
 		}
 	}
-	return defaultLoggingVersion, nil
+	return defaultLoggingVersion
 }
 
-func getClusterLogForwarderSpec(k8s client.Client, cluster *clusterv1.ManagedCluster, mcAddon *addonapiv1alpha1.ManagedClusterAddOn) (*loggingv1.ClusterLogForwarderSpec, error) {
+func buildClusterLogForwarderSpec(k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAddOn) (*loggingv1.ClusterLogForwarderSpec, error) {
 	key := addon.GetObjectKey(mcAddon.Status.ConfigReferences, loggingv1.GroupVersion.Group, clusterLogForwarderResource)
 	clf := &loggingv1.ClusterLogForwarder{}
 	if err := k8s.Get(context.Background(), key, clf, &client.GetOptions{}); err != nil {
@@ -66,11 +38,11 @@ func getClusterLogForwarderSpec(k8s client.Client, cluster *clusterv1.ManagedClu
 
 		switch config.ConfigGroupResource.Resource {
 		case addon.ConfigMapResource:
-			if err := getManagedClusterConfigMaps(k8s, &clf.Spec, config, cluster.Name); err != nil {
+			if err := templateWithConfigMap(k8s, &clf.Spec, config); err != nil {
 				return nil, err
 			}
 		case addon.SecretResource:
-			if err := getManagedClusterSecrets(k8s, &clf.Spec, config, cluster.Name); err != nil {
+			if err := templateWithSecret(k8s, &clf.Spec, config); err != nil {
 				return nil, err
 			}
 		}
@@ -79,8 +51,8 @@ func getClusterLogForwarderSpec(k8s client.Client, cluster *clusterv1.ManagedClu
 	return &clf.Spec, nil
 }
 
-func getManagedClusterConfigMaps(k8s client.Client, spec *loggingv1.ClusterLogForwarderSpec, config addonapiv1alpha1.ConfigReference, clusterNs string) error {
-	key := client.ObjectKey{Name: config.Name, Namespace: clusterNs}
+func templateWithConfigMap(k8s client.Client, spec *loggingv1.ClusterLogForwarderSpec, config addonapiv1alpha1.ConfigReference) error {
+	key := client.ObjectKey{Name: config.Name, Namespace: config.Namespace}
 	cm := &corev1.ConfigMap{}
 	if err := k8s.Get(context.Background(), key, cm, &client.GetOptions{}); err != nil {
 		if errors.IsNotFound(err) {
@@ -93,8 +65,10 @@ func getManagedClusterConfigMaps(k8s client.Client, spec *loggingv1.ClusterLogFo
 	if !ok {
 		return nil
 	}
+	// TODO(JoaoBraveCoding) Validate that clfOutputName actually exists
 
 	outputURL := cm.Data["url"]
+	// TODO(JoaoBraveCoding) Validate that is a valid URL
 
 	for k, output := range spec.Outputs {
 		if output.Name == clfOutputName {
@@ -105,8 +79,8 @@ func getManagedClusterConfigMaps(k8s client.Client, spec *loggingv1.ClusterLogFo
 	return nil
 }
 
-func getManagedClusterSecrets(k8s client.Client, spec *loggingv1.ClusterLogForwarderSpec, config addonapiv1alpha1.ConfigReference, clusterNs string) error {
-	key := client.ObjectKey{Name: config.Name, Namespace: clusterNs}
+func templateWithSecret(k8s client.Client, spec *loggingv1.ClusterLogForwarderSpec, config addonapiv1alpha1.ConfigReference) error {
+	key := client.ObjectKey{Name: config.Name, Namespace: config.Namespace}
 	secret := &corev1.Secret{}
 	if err := k8s.Get(context.Background(), key, secret, &client.GetOptions{}); err != nil {
 		if errors.IsNotFound(err) {
@@ -119,6 +93,8 @@ func getManagedClusterSecrets(k8s client.Client, spec *loggingv1.ClusterLogForwa
 	if !ok {
 		return nil
 	}
+	// TODO(JoaoBraveCoding) Validate that clfOutputName actually exists
+	// TODO(JoaoBraveCoding) Validate secret
 
 	for k, output := range spec.Outputs {
 		if output.Name == clfOutputName {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -61,6 +61,10 @@ func templateWithConfigMap(k8s client.Client, spec *loggingv1.ClusterLogForwarde
 		return err
 	}
 
+	if signal, ok := cm.Labels[addon.SignalLabelKey]; !ok || signal != addon.SignalLogging {
+		return nil
+	}
+
 	clfOutputName, ok := cm.Annotations[annotationTargetOutputName]
 	if !ok {
 		return nil
@@ -87,6 +91,10 @@ func templateWithSecret(k8s client.Client, spec *loggingv1.ClusterLogForwarderSp
 			return nil
 		}
 		return err
+	}
+
+	if signal, ok := secret.Labels[addon.SignalLabelKey]; !ok || signal != addon.SignalLogging {
+		return nil
 	}
 
 	clfOutputName, ok := secret.Annotations[annotationTargetOutputName]

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -5,145 +5,74 @@ import (
 	"testing"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
-	"github.com/rhobs/multicluster-observability-addon/internal/addon"
-
-	loggingapis "github.com/openshift/cluster-logging-operator/apis"
-	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
-	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
-	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var (
-	_ = loggingapis.AddToScheme(scheme.Scheme)
-	_ = operatorsv1.AddToScheme(scheme.Scheme)
-	_ = operatorsv1alpha1.AddToScheme(scheme.Scheme)
-)
-
-func fakeGetValues(k8s client.Client) addonfactory.GetValuesFunc {
-	return func(
-		cluster *clusterv1.ManagedCluster,
-		addon *addonapiv1alpha1.ManagedClusterAddOn,
-	) (addonfactory.Values, error) {
-		logging, err := GetValuesFunc(k8s, cluster, addon, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		return addonfactory.JsonStructToValues(logging)
-	}
-}
-
-func TestNewLoggingAgentAddon_WithFleetWideSubscriptionChannel(t *testing.T) {
-	var (
-		managedCluster        *clusterv1.ManagedCluster
-		managedClusterAddOn   *addonapiv1alpha1.ManagedClusterAddOn
-		addOnDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig
-	)
-
-	managedCluster = addontesting.NewManagedCluster("cluster-1")
-	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
-
-	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
+func Test_Logging_BuildSubscriptionChannel(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		key        string
+		value      string
+		subChannel string
+	}{
 		{
-			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-				Group:    "addon.open-cluster-management.io",
-				Resource: "addondeploymentconfigs",
-			},
-			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
-				Name:      "multicluster-observability-addon",
-			},
+			name:       "unknown key",
+			key:        "test",
+			value:      "stable-1.0",
+			subChannel: "stable-5.8",
 		},
-	}
-
-	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "multicluster-observability-addon",
-			Namespace: "open-cluster-management",
+		{
+			name:       "known key",
+			key:        "loggingSubscriptionChannel",
+			value:      "stable-5.7",
+			subChannel: "stable-5.7",
 		},
-		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
-			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-				{
-					Name:  "loggingSubscriptionChannel",
-					Value: "stable-5.8",
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adoc := &addonapiv1alpha1.AddOnDeploymentConfig{
+				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
+					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+						{
+							Name:  tc.key,
+							Value: tc.value,
+						},
+					},
 				},
-			},
-		},
-	}
-
-	fakeAddonClient := fakeaddon.NewSimpleClientset(addOnDeploymentConfig)
-	addonConfigValuesFn := addonfactory.GetAddOnDeploymentConfigValues(
-		addonfactory.NewAddOnDeploymentConfigGetter(fakeAddonClient),
-		addonfactory.ToAddOnCustomizedVariableValues,
-	)
-
-	loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, "manifests/charts/mcoa/charts/logging").
-		WithGetValuesFuncs(addonConfigValuesFn).
-		WithAgentRegistrationOption(&agent.RegistrationOption{}).
-		WithScheme(scheme.Scheme).
-		BuildHelmAgentAddon()
-	if err != nil {
-		klog.Fatalf("failed to build agent %v", err)
-	}
-
-	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
-	require.NoError(t, err)
-	require.Equal(t, 6, len(objects))
-
-	for _, obj := range objects {
-		switch obj := obj.(type) {
-		case *operatorsv1alpha1.Subscription:
-			require.Equal(t, obj.Spec.Channel, "stable-5.8")
-		}
+			}
+			subChannel := buildSubscriptionChannel(adoc)
+			require.Equal(t, tc.subChannel, subChannel)
+		})
 	}
 }
 
-func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsTogether(t *testing.T) {
+func Test_BuildCLFSpec(t *testing.T) {
 	var (
 		// Addon envinronment and registration
-		managedCluster      *clusterv1.ManagedCluster
 		managedClusterAddOn *addonapiv1alpha1.ManagedClusterAddOn
 
 		// Addon configuration
-		addOnDeploymentConfig            *addonapiv1alpha1.AddOnDeploymentConfig
 		clf                              *loggingv1.ClusterLogForwarder
 		appLogsSecret, clusterLogsSecret *corev1.Secret
 		appLogsCm                        *corev1.ConfigMap
 
 		// Test clients
-		fakeKubeClient  client.Client
-		fakeAddonClient *fakeaddon.Clientset
-	)
+		fakeKubeClient client.Client
 
-	// Setup a managed cluster
-	managedCluster = addontesting.NewManagedCluster("cluster-1")
+		clusterName = "cluster-1"
+	)
 
 	// Register the addon for the managed cluster
 	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
 	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
-		{
-			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-				Group:    "addon.open-cluster-management.io",
-				Resource: "addondeploymentconfigs",
-			},
-			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
-				Name:      "multicluster-observability-addon",
-			},
-		},
 		{
 			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    "logging.openshift.io",
@@ -160,8 +89,8 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 				Resource: "secrets",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: managedCluster.Name,
-				Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
+				Namespace: clusterName,
+				Name:      fmt.Sprintf("%s-app-logs", clusterName),
 			},
 		},
 		{
@@ -170,8 +99,8 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 				Resource: "secrets",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: managedCluster.Name,
-				Name:      fmt.Sprintf("%s-cluster-logs", managedCluster.Name),
+				Namespace: clusterName,
+				Name:      fmt.Sprintf("%s-cluster-logs", clusterName),
 			},
 		},
 		{
@@ -180,8 +109,8 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 				Resource: "configmaps",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: managedCluster.Name,
-				Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
+				Namespace: clusterName,
+				Name:      fmt.Sprintf("%s-app-logs", clusterName),
 			},
 		},
 	}
@@ -244,8 +173,8 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 
 	appLogsSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
-			Namespace: managedCluster.Name,
+			Name:      fmt.Sprintf("%s-app-logs", clusterName),
+			Namespace: clusterName,
 			Annotations: map[string]string{
 				annotationTargetOutputName: "app-logs",
 			},
@@ -258,8 +187,8 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 
 	clusterLogsSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-cluster-logs", managedCluster.Name),
-			Namespace: managedCluster.Name,
+			Name:      fmt.Sprintf("%s-cluster-logs", clusterName),
+			Namespace: clusterName,
 			Annotations: map[string]string{
 				annotationTargetOutputName: "cluster-logs",
 			},
@@ -272,8 +201,8 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 
 	appLogsCm = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
-			Namespace: managedCluster.Name,
+			Name:      fmt.Sprintf("%s-app-logs", clusterName),
+			Namespace: clusterName,
 			Annotations: map[string]string{
 				annotationTargetOutputName: "app-logs",
 			},
@@ -283,59 +212,98 @@ func TestNewLoggingAgentAddon_WithFleetWideClusterLogForwarder_AndAllConfigsToge
 		},
 	}
 
-	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "multicluster-observability-addon",
-			Namespace: "open-cluster-management",
-		},
-		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
-			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-				{
-					Name:  "loggingSubscriptionChannel",
-					Value: "stable-5.8",
-				},
-			},
-		},
-	}
-
 	// Setup the fake k8s client
 	fakeKubeClient = fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
 		WithObjects(clf, appLogsCm, appLogsSecret, clusterLogsSecret).
 		Build()
 
-	// Setup the fake addon client
-	fakeAddonClient = fakeaddon.NewSimpleClientset(addOnDeploymentConfig)
-	addonConfigValuesFn := addonfactory.GetAddOnDeploymentConfigValues(
-		addonfactory.NewAddOnDeploymentConfigGetter(fakeAddonClient),
-		addonfactory.ToAddOnCustomizedVariableValues,
-	)
-
-	// Wire everything together to a fake addon instance
-	loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, addon.LoggingChartDir).
-		WithGetValuesFuncs(addonConfigValuesFn, fakeGetValues(fakeKubeClient)).
-		WithAgentRegistrationOption(&agent.RegistrationOption{}).
-		WithScheme(scheme.Scheme).
-		BuildHelmAgentAddon()
-	if err != nil {
-		klog.Fatalf("failed to build agent %v", err)
-	}
-
-	// Render manifests and return them as k8s runtime objects
-	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
+	clfSpec, err := buildClusterLogForwarderSpec(fakeKubeClient, managedClusterAddOn)
 	require.NoError(t, err)
-	require.Equal(t, 6, len(objects))
+	require.NotNil(t, clfSpec.Outputs[0].Secret)
+	require.NotNil(t, clfSpec.Outputs[1].Secret)
+	require.Equal(t, appLogsSecret.Name, clfSpec.Outputs[0].Secret.Name)
+	require.Equal(t, clusterLogsSecret.Name, clfSpec.Outputs[1].Secret.Name)
+	require.Equal(t, appLogsCm.Data["url"], clfSpec.Outputs[0].URL)
 
-	for _, obj := range objects {
-		switch obj := obj.(type) {
-		case *operatorsv1alpha1.Subscription:
-			require.Equal(t, obj.Spec.Channel, "stable-5.8")
-		case *loggingv1.ClusterLogForwarder:
-			require.NotNil(t, obj.Spec.Outputs[0].Secret)
-			require.NotNil(t, obj.Spec.Outputs[1].Secret)
-			require.Equal(t, appLogsSecret.Name, obj.Spec.Outputs[0].Secret.Name)
-			require.Equal(t, clusterLogsSecret.Name, obj.Spec.Outputs[1].Secret.Name)
-			require.Equal(t, appLogsCm.Data["url"], obj.Spec.Outputs[0].URL)
-		}
+}
+
+func Test_TemplateWithConfigMap(t *testing.T) {
+	configReference := addonapiv1alpha1.ConfigReference{
+		ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+			Group:    "",
+			Resource: "configmap",
+		},
+		ConfigReferent: addonapiv1alpha1.ConfigReferent{
+			Namespace: "cluster-1",
+			Name:      "cluster-1",
+		},
 	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "cluster-1",
+			Annotations: map[string]string{
+				"logging.mcoa.openshift.io/target-output-name": "foo",
+			},
+		},
+		Data: map[string]string{
+			"url": "http://foo.bar",
+		},
+	}
+	client := fake.NewClientBuilder().
+		WithObjects(cm).
+		Build()
+
+	spec := &loggingv1.ClusterLogForwarderSpec{
+		Outputs: []loggingv1.OutputSpec{
+			{
+				Name: "foo",
+			},
+		},
+	}
+
+	err := templateWithConfigMap(client, spec, configReference)
+	assert.NoError(t, err, "Expected no error")
+	assert.Equal(t, "http://foo.bar", spec.Outputs[0].URL)
+}
+
+func Test_TemplateWithSecret(t *testing.T) {
+	configReference := addonapiv1alpha1.ConfigReference{
+		ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+			Group:    "",
+			Resource: "secret",
+		},
+		ConfigReferent: addonapiv1alpha1.ConfigReferent{
+			Namespace: "cluster-1",
+			Name:      "cluster-1",
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "cluster-1",
+			Annotations: map[string]string{
+				"logging.mcoa.openshift.io/target-output-name": "foo",
+			},
+		},
+	}
+	client := fake.NewClientBuilder().
+		WithObjects(secret).
+		Build()
+
+	spec := &loggingv1.ClusterLogForwarderSpec{
+		Outputs: []loggingv1.OutputSpec{
+			{
+				Name: "foo",
+			},
+		},
+	}
+
+	err := templateWithSecret(client, spec, configReference)
+	assert.NoError(t, err)
+	assert.NotNil(t, spec.Outputs[0].Secret)
+	assert.Equal(t, "cluster-1", spec.Outputs[0].Secret.Name)
 }

--- a/internal/logging/values.go
+++ b/internal/logging/values.go
@@ -1,0 +1,31 @@
+package logging
+
+import (
+	"encoding/json"
+
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetValuesFunc(k8s client.Client, _ *clusterv1.ManagedCluster, mcAddon *addonapiv1alpha1.ManagedClusterAddOn, adoc *addonapiv1alpha1.AddOnDeploymentConfig) (LoggingValues, error) {
+	values := LoggingValues{
+		Enabled: true,
+	}
+
+	values.LoggingSubscriptionChannel = buildSubscriptionChannel(adoc)
+
+	clfSpec, err := buildClusterLogForwarderSpec(k8s, mcAddon)
+	if err != nil {
+		return values, err
+	}
+
+	b, err := json.Marshal(clfSpec)
+	if err != nil {
+		return values, err
+	}
+
+	values.CLFSpec = string(b)
+
+	return values, nil
+}

--- a/internal/logging/values_test.go
+++ b/internal/logging/values_test.go
@@ -1,0 +1,341 @@
+package logging
+
+import (
+	"fmt"
+	"testing"
+
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/rhobs/multicluster-observability-addon/internal/addon"
+
+	loggingapis "github.com/openshift/cluster-logging-operator/apis"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
+	"open-cluster-management.io/addon-framework/pkg/agent"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	_ = loggingapis.AddToScheme(scheme.Scheme)
+	_ = operatorsv1.AddToScheme(scheme.Scheme)
+	_ = operatorsv1alpha1.AddToScheme(scheme.Scheme)
+)
+
+func fakeGetValues(k8s client.Client) addonfactory.GetValuesFunc {
+	return func(
+		cluster *clusterv1.ManagedCluster,
+		addon *addonapiv1alpha1.ManagedClusterAddOn,
+	) (addonfactory.Values, error) {
+		logging, err := GetValuesFunc(k8s, cluster, addon, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		return addonfactory.JsonStructToValues(logging)
+	}
+}
+
+func Test_Logging_SubscriptionChannel(t *testing.T) {
+	var (
+		managedCluster        *clusterv1.ManagedCluster
+		managedClusterAddOn   *addonapiv1alpha1.ManagedClusterAddOn
+		addOnDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig
+	)
+
+	managedCluster = addontesting.NewManagedCluster("cluster-1")
+	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
+
+	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "addon.open-cluster-management.io",
+				Resource: "addondeploymentconfigs",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: "open-cluster-management",
+				Name:      "multicluster-observability-addon",
+			},
+		},
+	}
+
+	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multicluster-observability-addon",
+			Namespace: "open-cluster-management",
+		},
+		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
+			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+				{
+					Name:  "loggingSubscriptionChannel",
+					Value: "stable-5.8",
+				},
+			},
+		},
+	}
+
+	fakeAddonClient := fakeaddon.NewSimpleClientset(addOnDeploymentConfig)
+	addonConfigValuesFn := addonfactory.GetAddOnDeploymentConfigValues(
+		addonfactory.NewAddOnDeploymentConfigGetter(fakeAddonClient),
+		addonfactory.ToAddOnCustomizedVariableValues,
+	)
+
+	loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, addon.LoggingChartDir).
+		WithGetValuesFuncs(addonConfigValuesFn).
+		WithAgentRegistrationOption(&agent.RegistrationOption{}).
+		WithScheme(scheme.Scheme).
+		BuildHelmAgentAddon()
+	if err != nil {
+		klog.Fatalf("failed to build agent %v", err)
+	}
+
+	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
+	require.NoError(t, err)
+	require.Equal(t, 6, len(objects))
+
+	for _, obj := range objects {
+		switch obj := obj.(type) {
+		case *operatorsv1alpha1.Subscription:
+			require.Equal(t, obj.Spec.Channel, "stable-5.8")
+		}
+	}
+}
+
+func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
+	var (
+		// Addon envinronment and registration
+		managedCluster      *clusterv1.ManagedCluster
+		managedClusterAddOn *addonapiv1alpha1.ManagedClusterAddOn
+
+		// Addon configuration
+		addOnDeploymentConfig            *addonapiv1alpha1.AddOnDeploymentConfig
+		clf                              *loggingv1.ClusterLogForwarder
+		appLogsSecret, clusterLogsSecret *corev1.Secret
+		appLogsCm                        *corev1.ConfigMap
+
+		// Test clients
+		fakeKubeClient  client.Client
+		fakeAddonClient *fakeaddon.Clientset
+	)
+
+	// Setup a managed cluster
+	managedCluster = addontesting.NewManagedCluster("cluster-1")
+
+	// Register the addon for the managed cluster
+	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
+	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "addon.open-cluster-management.io",
+				Resource: "addondeploymentconfigs",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: "open-cluster-management",
+				Name:      "multicluster-observability-addon",
+			},
+		},
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "logging.openshift.io",
+				Resource: "clusterlogforwarders",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: "open-cluster-management",
+				Name:      "instance",
+			},
+		},
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "",
+				Resource: "secrets",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: managedCluster.Name,
+				Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
+			},
+		},
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "",
+				Resource: "secrets",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: managedCluster.Name,
+				Name:      fmt.Sprintf("%s-cluster-logs", managedCluster.Name),
+			},
+		},
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "",
+				Resource: "configmaps",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: managedCluster.Name,
+				Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
+			},
+		},
+	}
+
+	// Setup configuration resources: ClusterLogForwarder, AddOnDeploymentConfig, Secrets, ConfigMaps
+	clf = &loggingv1.ClusterLogForwarder{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance",
+			Namespace: "open-cluster-management",
+		},
+		Spec: loggingv1.ClusterLogForwarderSpec{
+			Inputs: []loggingv1.InputSpec{
+				{
+					Name: "app-logs",
+					Application: &loggingv1.Application{
+						Namespaces: []string{"ns-1", "ns-2"},
+					},
+				},
+				{
+					Name:           "infra-logs",
+					Infrastructure: &loggingv1.Infrastructure{},
+				},
+			},
+			Outputs: []loggingv1.OutputSpec{
+				{
+					Name: "app-logs",
+					Type: loggingv1.OutputTypeLoki,
+					OutputTypeSpec: loggingv1.OutputTypeSpec{
+						Loki: &loggingv1.Loki{
+							LabelKeys: []string{"key-1", "key-2"},
+							TenantKey: "tenant-x",
+						},
+					},
+				},
+				{
+					Name: "cluster-logs",
+					Type: loggingv1.OutputTypeCloudwatch,
+					OutputTypeSpec: loggingv1.OutputTypeSpec{
+						Cloudwatch: &loggingv1.Cloudwatch{
+							GroupBy:     loggingv1.LogGroupByLogType,
+							GroupPrefix: pointer.String("test-prefix"),
+						},
+					},
+				},
+			},
+			Pipelines: []loggingv1.PipelineSpec{
+				{
+					Name:       "app-logs",
+					InputRefs:  []string{"app-logs"},
+					OutputRefs: []string{"app-logs"},
+				},
+				{
+					Name:       "cluster-logs",
+					InputRefs:  []string{"infra-logs", loggingv1.InputNameAudit},
+					OutputRefs: []string{"cluster-logs"},
+				},
+			},
+		},
+	}
+
+	appLogsSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
+			Namespace: managedCluster.Name,
+			Annotations: map[string]string{
+				annotationTargetOutputName: "app-logs",
+			},
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		},
+	}
+
+	clusterLogsSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-cluster-logs", managedCluster.Name),
+			Namespace: managedCluster.Name,
+			Annotations: map[string]string{
+				annotationTargetOutputName: "cluster-logs",
+			},
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		},
+	}
+
+	appLogsCm = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
+			Namespace: managedCluster.Name,
+			Annotations: map[string]string{
+				annotationTargetOutputName: "app-logs",
+			},
+		},
+		Data: map[string]string{
+			"url": "https://example.com",
+		},
+	}
+
+	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multicluster-observability-addon",
+			Namespace: "open-cluster-management",
+		},
+		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
+			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+				{
+					Name:  "loggingSubscriptionChannel",
+					Value: "stable-5.8",
+				},
+			},
+		},
+	}
+
+	// Setup the fake k8s client
+	fakeKubeClient = fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(clf, appLogsCm, appLogsSecret, clusterLogsSecret).
+		Build()
+
+	// Setup the fake addon client
+	fakeAddonClient = fakeaddon.NewSimpleClientset(addOnDeploymentConfig)
+	addonConfigValuesFn := addonfactory.GetAddOnDeploymentConfigValues(
+		addonfactory.NewAddOnDeploymentConfigGetter(fakeAddonClient),
+		addonfactory.ToAddOnCustomizedVariableValues,
+	)
+
+	// Wire everything together to a fake addon instance
+	loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, addon.LoggingChartDir).
+		WithGetValuesFuncs(addonConfigValuesFn, fakeGetValues(fakeKubeClient)).
+		WithAgentRegistrationOption(&agent.RegistrationOption{}).
+		WithScheme(scheme.Scheme).
+		BuildHelmAgentAddon()
+	if err != nil {
+		klog.Fatalf("failed to build agent %v", err)
+	}
+
+	// Render manifests and return them as k8s runtime objects
+	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
+	require.NoError(t, err)
+	require.Equal(t, 6, len(objects))
+
+	for _, obj := range objects {
+		switch obj := obj.(type) {
+		case *operatorsv1alpha1.Subscription:
+			require.Equal(t, obj.Spec.Channel, "stable-5.8")
+		case *loggingv1.ClusterLogForwarder:
+			require.NotNil(t, obj.Spec.Outputs[0].Secret)
+			require.NotNil(t, obj.Spec.Outputs[1].Secret)
+			require.Equal(t, appLogsSecret.Name, obj.Spec.Outputs[0].Secret.Name)
+			require.Equal(t, clusterLogsSecret.Name, obj.Spec.Outputs[1].Secret.Name)
+			require.Equal(t, appLogsCm.Data["url"], obj.Spec.Outputs[0].URL)
+		}
+	}
+}

--- a/internal/logging/values_test.go
+++ b/internal/logging/values_test.go
@@ -246,6 +246,9 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
 			Namespace: managedCluster.Name,
+			Labels: map[string]string{
+				"mcoa.openshift.io/signal": "logging",
+			},
 			Annotations: map[string]string{
 				annotationTargetOutputName: "app-logs",
 			},
@@ -260,6 +263,9 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-cluster-logs", managedCluster.Name),
 			Namespace: managedCluster.Name,
+			Labels: map[string]string{
+				"mcoa.openshift.io/signal": "logging",
+			},
 			Annotations: map[string]string{
 				annotationTargetOutputName: "cluster-logs",
 			},
@@ -274,6 +280,9 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-app-logs", managedCluster.Name),
 			Namespace: managedCluster.Name,
+			Labels: map[string]string{
+				"mcoa.openshift.io/signal": "logging",
+			},
 			Annotations: map[string]string{
 				annotationTargetOutputName: "app-logs",
 			},

--- a/internal/logging/var.go
+++ b/internal/logging/var.go
@@ -1,7 +1,7 @@
 package logging
 
 const (
-	annotationTargetOutputName = "logging.openshift.io/target-output-name"
+	annotationTargetOutputName = "logging.mcoa.openshift.io/target-output-name"
 
 	subscriptionChannelValueKey = "loggingSubscriptionChannel"
 	defaultLoggingVersion       = "stable-5.8"


### PR DESCRIPTION
This PR adds:
- addon: adds testing case to make sure the enable and disable signal feature works 
- logging: adds a requirement for common resources (secrets, configmaps) to have the signal label;
- logging: adds tests to test individually each logging auxiliary function