### PR TITLE
Metrics: label helper refactor and fix for SA name

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/_helpers.tpl
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/_helpers.tpl
@@ -7,3 +7,12 @@
 {{- define "metricshelm.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "metricshelm.labels" }}
+app: {{ template "metricshelm.name" . }}
+app.kubernetes.io/name: {{ include "metricshelm.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+release: {{.Release.Name }}
+app.kubernetes.io/part-of: multicluster-observability-addon
+{{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/_helpers.tpl
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/_helpers.tpl
@@ -11,8 +11,7 @@
 {{/* Generate basic labels */}}
 {{- define "metricshelm.labels" }}
 app: {{ template "metricshelm.name" . }}
-app.kubernetes.io/name: {{ include "metricshelm.name" . }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-release: {{.Release.Name }}
+release: {{ .Release.Name }}
 app.kubernetes.io/part-of: multicluster-observability-addon
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/_helpers.tpl
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/_helpers.tpl
@@ -11,7 +11,7 @@
 {{/* Generate basic labels */}}
 {{- define "metricshelm.labels" }}
 app: {{ template "metricshelm.name" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+chart: {{ template "metricshelm.chart" . }}
 release: {{ .Release.Name }}
 app.kubernetes.io/part-of: multicluster-observability-addon
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -3,6 +3,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multicluster-observability-addon:metrics:agent
+  labels:
+    {{- include "metricshelm.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -5,7 +5,6 @@ metadata:
   name: multicluster-observability-addon:metrics:agent
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
-    app.kubernetes.io/component: metrics-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   name: multicluster-observability-addon:metrics:agent
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
+    app.kubernetes.io/component: metrics-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: multicluster-observability-addon:metrics:agent
 subjects:
   - kind: ServiceAccount
-    name: multicluster-observability-addon:metrics:agent
+    name: multicluster-observability-metrics
     namespace: {{ .Values.addonInstallNamespace }}
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -5,9 +5,8 @@ metadata:
   name: prometheus-agent-conf
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
-    app.kubernetes.io/component: metrics-agent
-    app.kubernetes.io/version: 2.48.1
     {{- include "metricshelm.labels" . | indent 4 }}
+    app.kubernetes.io/component: metrics-agent
 data:
   prometheus.yml: |-
     global:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
-    app.kubernetes.io/component: metrics-agent
 data:
   prometheus.yml: |-
     global:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -5,11 +5,9 @@ metadata:
   name: prometheus-agent-conf
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
-    app.kubernetes.io/part-of: multicluster-observability-addon
     app.kubernetes.io/component: metrics-agent
-    app.kubernetes.io/instance: metrics-agent
-    app.kubernetes.io/name: prometheus-agent-conf
     app.kubernetes.io/version: 2.48.1
+    {{- include "metricshelm.labels" . | indent 4 }}
 data:
   prometheus.yml: |-
     global:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-addon-agent
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
-    app.kubernetes.io/part-of: multicluster-observability-addon
+    {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent
     app.kubernetes.io/instance: metrics-agent
     app.kubernetes.io/name: metrics-addon-agent
@@ -14,14 +14,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/part-of: multicluster-observability-addon
+      {{- include "metricshelm.labels" . | indent 6 }}
       app.kubernetes.io/component: metrics-agent
       app.kubernetes.io/instance: metrics-agent
       app.kubernetes.io/name: metrics-addon-agent
   template:
     metadata:
       labels:
-        app.kubernetes.io/part-of: multicluster-observability-addon
+        {{- include "metricshelm.labels" . | indent 8 }}
         app.kubernetes.io/component: metrics-agent
         app.kubernetes.io/instance: metrics-agent
         app.kubernetes.io/name: metrics-addon-agent

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent
-    app.kubernetes.io/instance: metrics-agent
-    app.kubernetes.io/name: metrics-addon-agent
     app.kubernetes.io/version: 2.48.1
 spec:
   replicas: 1
@@ -16,17 +14,13 @@ spec:
     matchLabels:
       {{- include "metricshelm.labels" . | indent 6 }}
       app.kubernetes.io/component: metrics-agent
-      app.kubernetes.io/instance: metrics-agent
-      app.kubernetes.io/name: metrics-addon-agent
   template:
     metadata:
       labels:
         {{- include "metricshelm.labels" . | indent 8 }}
         app.kubernetes.io/component: metrics-agent
-        app.kubernetes.io/instance: metrics-agent
-        app.kubernetes.io/name: metrics-addon-agent
     spec:
-      serviceAccountName: multicluster-observability-addon:metrics:agent
+      serviceAccountName: multicluster-observability-metrics
       volumes:
         - name: prometheus-config-volume
           configMap:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent
-    app.kubernetes.io/version: 2.48.1
 spec:
   replicas: 1
   selector:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/role.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/role.yaml
@@ -5,7 +5,6 @@ metadata:
   name: multicluster-observability-addon:metrics:agent
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
-    app.kubernetes.io/component: metrics-agent
 rules:
   - apiGroups: [""]
     resources:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/role.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/role.yaml
@@ -5,6 +5,7 @@ metadata:
   name: multicluster-observability-addon:metrics:agent
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
+    app.kubernetes.io/component: metrics-agent
 rules:
   - apiGroups: [""]
     resources:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/role.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/role.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multicluster-observability-addon:metrics:agent
+  labels:
+    {{- include "metricshelm.labels" . | indent 4 }}
 rules:
   - apiGroups: [""]
     resources:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -2,11 +2,9 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: multicluster-observability-addon:metrics:agent
+  name: multicluster-observability-metrics
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent
-    app.kubernetes.io/instance: metrics-agent
-    app.kubernetes.io/name: metrics-addon-sa
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -6,5 +6,4 @@ metadata:
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
-    app.kubernetes.io/component: metrics-agent
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: multicluster-observability-addon:metrics:agent
   namespace: {{ .Values.addonInstallNamespace }}
   labels:
-    app.kubernetes.io/part-of: multicluster-observability-addon
+    {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent
     app.kubernetes.io/instance: metrics-agent
     app.kubernetes.io/name: metrics-addon-sa


### PR DESCRIPTION
This PR refactors the labels of the metrics component into a helper. I tried to use labels similar to the logging chart's and removed any label that I didn't feel like was required. 

We can/might use different labels in the future.

I also fixed the SA name that became invalid due to special characters.