### PR TITLE
addon: fixes ClusterIssuer resource

### DIFF
--- a/internal/manifests/secrets.go
+++ b/internal/manifests/secrets.go
@@ -150,7 +150,6 @@ func BuildAllRootCertificate() []client.Object {
 	cIssuer := &certmanagerv1.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterIssuerName,
-			Namespace: certManagerNamespace,
 		},
 		Spec: certmanagerv1.IssuerSpec{
 			IssuerConfig: certmanagerv1.IssuerConfig{

--- a/internal/manifests/secrets.go
+++ b/internal/manifests/secrets.go
@@ -149,7 +149,7 @@ func BuildAllRootCertificate() []client.Object {
 
 	cIssuer := &certmanagerv1.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterIssuerName,
+			Name: clusterIssuerName,
 		},
 		Spec: certmanagerv1.IssuerSpec{
 			IssuerConfig: certmanagerv1.IssuerConfig{


### PR DESCRIPTION
ClusterIssuer is a cluster-scoped resource so it doesn't have a namespace