### PR TITLE
addon: authentication adds option to inject a CA in mTLS secrets

### DIFF
--- a/internal/addon/authentication/provider.go
+++ b/internal/addon/authentication/provider.go
@@ -14,28 +14,35 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// AuthenticationType defines the type of authentication that will be used for a target.
+// AuthenticationType defines a authentication method between two endpoints
 type AuthenticationType string
 
+// Target defines the name of an endpoint that will be available to store
+// signal data
+type Target string
+
+// SecretKey defines a key pair (Name/Namespace) that points to a Secret on the
+// hub cluster in the namespace of the spoke cluster
+type SecretKey client.ObjectKey
+
+// Config defines the configuration supported by the authentication package
+// to adapt the secret generation to the needs of each signal
 type Config struct {
 	StaticAuthConfig manifests.StaticAuthenticationConfig
 	MTLSConfig       manifests.MTLSConfig
 }
 
-// secretsProvider is a struct that holds the Kubernetes client and configuration.
+// secretsProvider an implementaton of the authentication package API
 type secretsProvider struct {
-	ctx         context.Context
 	k8s         client.Client
 	clusterName string
 	signal      addon.Signal
 	Config
 }
 
-// NewSecretsProvider creates a new instance of K8sSecretGenerator.
+// NewSecretsProvider creates a new instance of *secretsProvider.
 func NewSecretsProvider(k8s client.Client, clusterName string, signal addon.Signal, config *Config) (*secretsProvider, error) {
-	ctx := context.Background()
 	secretsProvider := &secretsProvider{
-		ctx:         ctx,
 		k8s:         k8s,
 		clusterName: clusterName,
 		signal:      signal,
@@ -49,12 +56,14 @@ func NewSecretsProvider(k8s client.Client, clusterName string, signal addon.Sign
 	return secretsProvider, nil
 }
 
-// GenerateSecrets generates Kubernetes secrets based on the specified authentication types for each target.
-// The provided targetAuthType map represents a set of targets, where each key corresponds to a target that
-// will receive signal data using a specific authentication type. This function returns a map with the same target
-// keys, where the values are `client.ObjectKey` representing the Kubernetes secret created for each target.
-func (sp *secretsProvider) GenerateSecrets(targetAuthType map[string]string) (map[string]client.ObjectKey, error) {
-	secretKeys := make(map[string]client.ObjectKey, len(targetAuthType))
+// GenerateSecrets requests Kubernetes secrets based on the specified
+// authentication method for each target. The provided targetAuthType map
+// represents a set of targets, where each key corresponds to a Target that that
+// uses a specific AuthenticationType. This function returns a map with the same
+// Target as keys, where the values are `SecretKey` referencing the Kubernetes
+// secret created.
+func (sp *secretsProvider) GenerateSecrets(ctx context.Context, targetAuthType map[Target]AuthenticationType) (map[Target]SecretKey, error) {
+	secretKeys := make(map[Target]SecretKey, len(targetAuthType))
 	objects := make([]client.Object, 0, len(targetAuthType))
 	for targetName, authType := range targetAuthType {
 		secretKey := client.ObjectKey{Name: fmt.Sprintf("%s-%s-auth", sp.signal, targetName), Namespace: sp.clusterName}
@@ -62,9 +71,9 @@ func (sp *secretsProvider) GenerateSecrets(targetAuthType map[string]string) (ma
 			obj client.Object
 			err error
 		)
-		switch AuthenticationType(authType) {
+		switch authType {
 		case Static:
-			obj, err = manifests.BuildStaticSecret(sp.ctx, sp.k8s, secretKey, sp.StaticAuthConfig)
+			obj, err = manifests.BuildStaticSecret(ctx, sp.k8s, secretKey, sp.StaticAuthConfig)
 		case Managed:
 			obj, err = manifests.BuildManagedSecret(secretKey)
 		case MTLS:
@@ -78,14 +87,14 @@ func (sp *secretsProvider) GenerateSecrets(targetAuthType map[string]string) (ma
 			return nil, err
 		}
 		objects = append(objects, obj)
-		secretKeys[targetName] = secretKey
+		secretKeys[targetName] = SecretKey(secretKey)
 	}
 
 	for _, obj := range objects {
 		desired := obj.DeepCopyObject().(client.Object)
 		mutateFn := manifests.MutateFuncFor(obj, desired, nil)
 
-		op, err := ctrl.CreateOrUpdate(sp.ctx, sp.k8s, obj, mutateFn)
+		op, err := ctrl.CreateOrUpdate(ctx, sp.k8s, obj, mutateFn)
 		if err != nil {
 			klog.Error(err, "failed to configure resource")
 			continue
@@ -100,7 +109,7 @@ func (sp *secretsProvider) GenerateSecrets(targetAuthType map[string]string) (ma
 		}
 	}
 
-	err := sp.injectCA(targetAuthType, secretKeys)
+	err := sp.injectCA(ctx, targetAuthType, secretKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -108,34 +117,40 @@ func (sp *secretsProvider) GenerateSecrets(targetAuthType map[string]string) (ma
 	return secretKeys, nil
 }
 
-func (sp *secretsProvider) FetchSecrets(targetsSecret map[string]client.ObjectKey, targetAnnotation string) ([]corev1.Secret, error) {
+// FetchSecrets given a map of Target and SecretKey it will get the Secret from
+// the hub cluster and add an annotation to it with Target. The goal of the
+// annotation is to preseve the link betweeen Target and Secret.
+// Note: the secret is not updated on the cluster with the annotation
+func (sp *secretsProvider) FetchSecrets(ctx context.Context, targetsSecret map[Target]SecretKey, targetAnnotation string) ([]corev1.Secret, error) {
 	secrets := make([]corev1.Secret, 0, len(targetsSecret))
 	for target, key := range targetsSecret {
 		secret := &corev1.Secret{}
-		if err := sp.k8s.Get(sp.ctx, key, secret, &client.GetOptions{}); err != nil {
+		if err := sp.k8s.Get(ctx, client.ObjectKey(key), secret, &client.GetOptions{}); err != nil {
 			return secrets, err
 		}
 		if secret.Annotations == nil {
 			secret.Annotations = make(map[string]string)
 		}
-		secret.Annotations[targetAnnotation] = target
+		secret.Annotations[targetAnnotation] = string(target)
 		secrets = append(secrets, *secret)
 	}
 	return secrets, nil
 }
 
-func (sp *secretsProvider) injectCA(targetAuthType map[string]string, targetsSecret map[string]client.ObjectKey) error {
+// injectCA will for Target's that requested mTLS authentication inject in the secret
+// an "ca-bundle.crt" key containing the CA configured in the secretsProvider Config
+func (sp *secretsProvider) injectCA(ctx context.Context, targetAuthType map[Target]AuthenticationType, targetsSecret map[Target]SecretKey) error {
 	if sp.MTLSConfig.CAToInject == "" {
 		return nil
 	}
 
 	objects := []client.Object{}
 	for target, authType := range targetAuthType {
-		switch AuthenticationType(authType) {
+		switch authType {
 		case MTLS:
 			secret := &corev1.Secret{}
-			key := targetsSecret[target]
-			if err := sp.k8s.Get(sp.ctx, key, secret, &client.GetOptions{}); err != nil {
+			key := client.ObjectKey(targetsSecret[target])
+			if err := sp.k8s.Get(ctx, key, secret, &client.GetOptions{}); err != nil {
 				return err
 			}
 			manifests.InjectCA(secret, sp.MTLSConfig.CAToInject)
@@ -147,7 +162,7 @@ func (sp *secretsProvider) injectCA(targetAuthType map[string]string, targetsSec
 		desired := obj.DeepCopyObject().(client.Object)
 		mutateFn := manifests.MutateFuncFor(obj, desired, nil)
 
-		op, err := ctrl.CreateOrUpdate(sp.ctx, sp.k8s, obj, mutateFn)
+		op, err := ctrl.CreateOrUpdate(ctx, sp.k8s, obj, mutateFn)
 		if err != nil {
 			klog.Error(err, "failed to configure resource")
 			continue
@@ -162,4 +177,16 @@ func (sp *secretsProvider) injectCA(targetAuthType map[string]string, targetsSec
 		}
 	}
 	return nil
+}
+
+func BuildAuthenticationMap(inputMap map[string]string) map[Target]AuthenticationType {
+	result := make(map[Target]AuthenticationType, len(inputMap))
+
+	for key, value := range inputMap {
+		target := Target(key)
+		authType := AuthenticationType(value)
+		result[target] = authType
+	}
+
+	return result
 }

--- a/internal/addon/authentication/provider.go
+++ b/internal/addon/authentication/provider.go
@@ -14,7 +14,7 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// AuthenticationType defines a authentication method between two endpoints
+// AuthenticationType defines an authentication method between two endpoints
 type AuthenticationType string
 
 // Target defines the name of an endpoint that will be available to store

--- a/internal/addon/authentication/provider_test.go
+++ b/internal/addon/authentication/provider_test.go
@@ -47,10 +47,10 @@ func Test_FetchSecrets(t *testing.T) {
 	spConfig := &Config{}
 	sp, err := NewSecretsProvider(fakeKubeClient, "test", "logging", spConfig)
 	require.NoError(t, err)
-	keys := map[string]client.ObjectKey{
+	keys := map[Target]SecretKey{
 		"target-1": {Name: "foo", Namespace: "bar"},
 	}
-	secrets, err := sp.FetchSecrets(keys, "foo-annotation")
+	secrets, err := sp.FetchSecrets(context.TODO(), keys, "foo-annotation")
 	require.NoError(t, err)
 	require.Len(t, secrets, 1)
 	require.Equal(t, sFoo.Name, secrets[0].Name)
@@ -84,13 +84,13 @@ func Test_InjectCA(t *testing.T) {
 	}}
 	sp, err := NewSecretsProvider(fakeKubeClient, "test", "logging", spConfig)
 	require.NoError(t, err)
-	targetAuth := map[string]string{
+	targetAuth := map[Target]AuthenticationType{
 		"target-1": "mTLS",
 	}
-	targetKeys := map[string]client.ObjectKey{
-		"target-1": key,
+	targetKeys := map[Target]SecretKey{
+		"target-1": SecretKey(key),
 	}
-	err = sp.injectCA(targetAuth, targetKeys)
+	err = sp.injectCA(context.TODO(), targetAuth, targetKeys)
 	require.NoError(t, err)
 	secret := &corev1.Secret{}
 	err = fakeKubeClient.Get(context.TODO(), key, secret, &client.GetOptions{})

--- a/internal/addon/authentication/provider_test.go
+++ b/internal/addon/authentication/provider_test.go
@@ -1,0 +1,101 @@
+package authentication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rhobs/multicluster-observability-addon/internal/manifests"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_FetchSecrets(t *testing.T) {
+	var (
+		annotation     = "foo-annotation"
+		target         = "target-1"
+		expAnnotations = map[string]string{
+			annotation: target,
+		}
+	)
+
+	sFoo := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+	}
+	sBaz := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "baz",
+			Namespace: "qux",
+		},
+		Data: map[string][]byte{
+			"baz": []byte("qux"),
+		},
+	}
+
+	fakeKubeClient := fake.NewClientBuilder().
+		WithObjects(sFoo, sBaz).
+		Build()
+
+	spConfig := &Config{}
+	sp, err := NewSecretsProvider(fakeKubeClient, "test", "logging", spConfig)
+	require.NoError(t, err)
+	keys := map[string]client.ObjectKey{
+		"target-1": {Name: "foo", Namespace: "bar"},
+	}
+	secrets, err := sp.FetchSecrets(keys, "foo-annotation")
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	require.Equal(t, sFoo.Name, secrets[0].Name)
+	require.Equal(t, expAnnotations, secrets[0].Annotations)
+}
+
+func Test_InjectCA(t *testing.T) {
+	var (
+		key = client.ObjectKey{
+			Name:      "foo",
+			Namespace: "bar",
+		}
+		ca = "foo-ca"
+	)
+	sFoo := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+	}
+
+	fakeKubeClient := fake.NewClientBuilder().
+		WithObjects(sFoo).
+		Build()
+
+	spConfig := &Config{MTLSConfig: manifests.MTLSConfig{
+		CAToInject: ca,
+	}}
+	sp, err := NewSecretsProvider(fakeKubeClient, "test", "logging", spConfig)
+	require.NoError(t, err)
+	targetAuth := map[string]string{
+		"target-1": "mTLS",
+	}
+	targetKeys := map[string]client.ObjectKey{
+		"target-1": key,
+	}
+	err = sp.injectCA(targetAuth, targetKeys)
+	require.NoError(t, err)
+	secret := &corev1.Secret{}
+	err = fakeKubeClient.Get(context.TODO(), key, secret, &client.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, sFoo.Name, secret.Name)
+	require.Equal(t, sFoo.Data["foo"], secret.Data["foo"])
+	require.Equal(t, []byte(ca), secret.Data["ca-bundle.crt"])
+}

--- a/internal/addon/authentication/var.go
+++ b/internal/addon/authentication/var.go
@@ -1,11 +1,5 @@
 package authentication
 
-import (
-	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/rhobs/multicluster-observability-addon/internal/manifests"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
 const (
 	// Static represents static authentication type.
 	Static AuthenticationType = "StaticAuthentication"
@@ -17,25 +11,4 @@ const (
 	MCO AuthenticationType = "MCO"
 )
 
-var (
-	metricsDefaults = ProviderConfig{}
-
-	loggingDefaults = ProviderConfig{
-		StaticAuthConfig: manifests.StaticAuthenticationConfig{
-			ExistingSecret: client.ObjectKey{
-				Name:      "static-authentication",
-				Namespace: "open-cluster-management",
-			},
-		},
-		// TODO(JoaoBraveCoding) Implement when support for LokiStack is added
-		MTLSConfig: manifests.MTLSConfig{
-			CommonName: "",
-			Subject:    &v1.X509Subject{},
-			DNSNames:   []string{},
-		},
-	}
-
-	tracingDefaults = ProviderConfig{}
-
-	certManagerCRDs = []string{"certificates.cert-manager.io", "issuers.cert-manager.io", "clusterissuers.cert-manager.io"}
-)
+var certManagerCRDs = []string{"certificates.cert-manager.io", "issuers.cert-manager.io", "clusterissuers.cert-manager.io"}

--- a/internal/logging/handlers/handler.go
+++ b/internal/logging/handlers/handler.go
@@ -43,7 +43,11 @@ func BuildOptions(k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAdd
 		}
 	}
 
-	secretsProvider := authentication.NewSecretsProvider(k8s, mcAddon.Namespace, addon.Logging, nil)
+	secretsProvider, err := authentication.NewSecretsProvider(k8s, mcAddon.Namespace, addon.Logging, manifests.AuthDefaultConfig)
+	if err != nil {
+		return resources, err
+	}
+
 	targetsSecret, err := secretsProvider.GenerateSecrets(authCM.Data)
 	if err != nil {
 		return resources, err

--- a/internal/logging/handlers/handler.go
+++ b/internal/logging/handlers/handler.go
@@ -48,12 +48,13 @@ func BuildOptions(k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAdd
 		return resources, err
 	}
 
-	targetsSecret, err := secretsProvider.GenerateSecrets(authCM.Data)
+	ctx := context.Background()
+	targetsSecret, err := secretsProvider.GenerateSecrets(ctx, authentication.BuildAuthenticationMap(authCM.Data))
 	if err != nil {
 		return resources, err
 	}
 
-	resources.Secrets, err = secretsProvider.FetchSecrets(targetsSecret, manifests.AnnotationTargetOutputName)
+	resources.Secrets, err = secretsProvider.FetchSecrets(ctx, targetsSecret, manifests.AnnotationTargetOutputName)
 	if err != nil {
 		return resources, err
 	}

--- a/internal/logging/manifests/var.go
+++ b/internal/logging/manifests/var.go
@@ -1,8 +1,30 @@
 package manifests
 
+import (
+	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/rhobs/multicluster-observability-addon/internal/addon/authentication"
+	"github.com/rhobs/multicluster-observability-addon/internal/manifests"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 const (
 	AnnotationTargetOutputName = "logging.mcoa.openshift.io/target-output-name"
 
 	subscriptionChannelValueKey = "loggingSubscriptionChannel"
 	defaultLoggingVersion       = "stable-5.8"
 )
+
+var AuthDefaultConfig = &authentication.Config{
+	StaticAuthConfig: manifests.StaticAuthenticationConfig{
+		ExistingSecret: client.ObjectKey{
+			Name:      "static-authentication",
+			Namespace: "open-cluster-management",
+		},
+	},
+	// TODO(JoaoBraveCoding) Implement when support for LokiStack is added
+	MTLSConfig: manifests.MTLSConfig{
+		CommonName: "",
+		Subject:    &v1.X509Subject{},
+		DNSNames:   []string{},
+	},
+}

--- a/internal/manifests/secrets.go
+++ b/internal/manifests/secrets.go
@@ -16,6 +16,7 @@ const (
 	rootCertName         = "mcoa-root-certificate"
 	clusterIssuerName    = "mcoa-cluster-issuer"
 	certManagerNamespace = "cert-manager"
+	caKey                = "ca-bundle.crt"
 )
 
 type StaticAuthenticationConfig struct {
@@ -23,6 +24,7 @@ type StaticAuthenticationConfig struct {
 }
 
 type MTLSConfig struct {
+	CAToInject string
 	CommonName string
 	Subject    *certmanagerv1.X509Subject
 	DNSNames   []string
@@ -160,4 +162,8 @@ func BuildAllRootCertificate() []client.Object {
 		},
 	}
 	return []client.Object{issuer, cert, cIssuer}
+}
+
+func InjectCA(secret *corev1.Secret, ca string) {
+	secret.Data[caKey] = []byte(ca)
 }

--- a/internal/manifests/secrets_test.go
+++ b/internal/manifests/secrets_test.go
@@ -63,3 +63,15 @@ func Test_BuildMTLSSecret(t *testing.T) {
 	require.Equal(t, "mcoa-cluster-issuer", c.Spec.IssuerRef.Name)
 	require.ElementsMatch(t, mTLSConfig.DNSNames, c.Spec.DNSNames)
 }
+
+func Test_InjectCA(t *testing.T) {
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+	}
+	ca := "test"
+	InjectCA(secret, ca)
+	require.Equal(t, []byte("bar"), secret.Data["foo"])
+	require.Equal(t, []byte("test"), secret.Data["ca-bundle.crt"])
+}


### PR DESCRIPTION
This PR adds:

- A new function to the authentication package (`injectCA`) that is called at the end of the `GenerateSecrets`  function. This function will inject a configured CA on mTLS secrets under the key `ca-bundle.crt`.

Open questions:

- Should the authentication package be configurable with a CA in string format (current implementation) or should it be configurable with a `client.ObjectKey` that will point to a secret that contains the CA.
- Should the `injectCA` function be called at the end of `GenerateSecrets`  (current implementation) or should it be called separately?