### PR TITLE
metrics: fix the namespace for the metrics chart

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: multicluster-observability-metrics
-    namespace: {{ .Values.addonInstallNamespace }}
+    namespace: {{.Release.Namespace }}
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: multicluster-observability-metrics
-    namespace: {{.Release.Namespace }}
+    namespace: open-cluster-management-addon-observability
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-agent-conf
-  namespace: {{.Release.Namespace }}
+  namespace: open-cluster-management-addon-observability
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
 data:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-agent-conf
-  namespace: {{ .Values.addonInstallNamespace }}
+  namespace: {{.Release.Namespace }}
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
 data:

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: metrics-addon-agent
-  namespace: {{ .Values.addonInstallNamespace }}
+  namespace: {{.Release.Namespace }}
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: metrics-addon-agent
-  namespace: {{.Release.Namespace }}
+  namespace: open-cluster-management-addon-observability
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
     app.kubernetes.io/component: metrics-agent

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: multicluster-observability-metrics
-  namespace: {{ .Values.addonInstallNamespace }}
+  namespace: {{.Release.Namespace }}
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: multicluster-observability-metrics
-  namespace: {{.Release.Namespace }}
+  namespace: open-cluster-management-addon-observability
   labels:
     {{- include "metricshelm.labels" . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
For now we have to match the MCO's namespace anyway for the metrics signal to work, so let's leave it hardcoded until this limitation goes away.