### PR TITLE
addon: fix name of secret generated by Certificate

### DIFF
--- a/internal/manifests/secrets.go
+++ b/internal/manifests/secrets.go
@@ -59,7 +59,7 @@ func BuildCertificate(key client.ObjectKey, mTLSConfig MTLSConfig) (*certmanager
 			Namespace: certKey.Namespace,
 		},
 		Spec: certmanagerv1.CertificateSpec{
-			SecretName: key.Namespace,
+			SecretName: key.Name,
 			CommonName: mTLSConfig.CommonName, // Signal specific
 			Subject:    mTLSConfig.Subject,    // Signal specific
 			DNSNames:   mTLSConfig.DNSNames,   // Signal specific

--- a/internal/manifests/secrets_test.go
+++ b/internal/manifests/secrets_test.go
@@ -42,7 +42,7 @@ func Test_BuildStaticSecret(t *testing.T) {
 }
 
 func Test_BuildMTLSSecret(t *testing.T) {
-	key := client.ObjectKey{Name: "foo", Namespace: "foo"}
+	key := client.ObjectKey{Name: "foo", Namespace: "bar"}
 	mTLSConfig := MTLSConfig{
 		CommonName: "foo",
 		Subject: &certmanagerv1.X509Subject{


### PR DESCRIPTION
Tested while implementing LokiStack support