### PR TITLE
logging: fix secret generation and BuildOptions

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/logging/templates/secret.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/logging/templates/secret.yaml
@@ -10,5 +10,6 @@ metadata:
     chart: {{ template "logginghelm.chart" $ }}
     release: {{ $.Release.Name }}
 data: {{ fromJson $secret_config.data | toYaml | nindent 2 }}
+---
 {{- end }}
 {{- end }}

--- a/internal/logging/handlers/handler.go
+++ b/internal/logging/handlers/handler.go
@@ -29,7 +29,7 @@ func BuildOptions(k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAdd
 	resources.ClusterLogForwarder = clf
 
 	authCM := &corev1.ConfigMap{}
-	for _, config := range mcAddon.Status.ConfigReferences {
+	for _, config := range mcAddon.Spec.Configs {
 		switch config.ConfigGroupResource.Resource {
 		case addon.ConfigMapResource:
 			key := client.ObjectKey{Name: config.Name, Namespace: config.Namespace}

--- a/internal/logging/helm_test.go
+++ b/internal/logging/helm_test.go
@@ -74,6 +74,18 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 
 	// Register the addon for the managed cluster
 	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
+	managedClusterAddOn.Spec.Configs = []addonapiv1alpha1.AddOnConfig{
+		{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+				Group:    "",
+				Resource: "configmaps",
+			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: "open-cluster-management",
+				Name:      "logging-auth",
+			},
+		},
+	}
 	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
 		{
 			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
@@ -93,16 +105,6 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
 				Namespace: "open-cluster-management",
 				Name:      "instance",
-			},
-		},
-		{
-			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-				Group:    "",
-				Resource: "configmaps",
-			},
-			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
-				Name:      "logging-auth",
 			},
 		},
 	}
@@ -229,7 +231,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 	// Render manifests and return them as k8s runtime objects
 	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
 	require.NoError(t, err)
-	require.Equal(t, 6, len(objects))
+	require.Equal(t, 7, len(objects))
 
 	for _, obj := range objects {
 		switch obj := obj.(type) {


### PR DESCRIPTION
This PR fixes:
- Generation of secres by the help chart was bugged due to a missing separator, so when multiple secrets had to be created in the spoke cluster we would only see 1 created.
- AddOnFramework only support 1 reference by GVK, before we were looping through the Status of the ManagedClusterAddOn but we changed to loop through the Spec as to avoid this limitation, this is a hack and should be fixed in the future