### PR TITLE
Extract the CA from the secret instead of storing it in a CM

### DIFF
--- a/internal/tracing/manifests/otelcol/exporter.go
+++ b/internal/tracing/manifests/otelcol/exporter.go
@@ -51,15 +51,15 @@ func ConfigureExportersEndpoints(cfg map[string]interface{}, cm corev1.ConfigMap
 		if otelExporterName != exporterName {
 			continue
 		}
-		var configMap map[interface{}]interface{}
+		var configMap map[string]interface{}
 		if config == nil {
-			configMap = make(map[interface{}]interface{})
+			configMap = make(map[string]interface{})
 			exporters[otelExporterName] = configMap
 		} else {
-			configMap = config.(map[interface{}]interface{})
+			configMap = config.(map[string]interface{})
 		}
 
-		err := configureExporterEndpoint(&configMap, cm)
+		err := configureExporterEndpoint(configMap, cm)
 		if err != nil {
 			return err
 		}
@@ -83,16 +83,16 @@ func configureExporterSecrets(exporter *map[interface{}]interface{}, secret core
 	certConfig["insecure"] = false
 	certConfig["cert_file"] = fmt.Sprintf("%s/tls.crt", folder)
 	certConfig["key_file"] = fmt.Sprintf("%s/tls.key", folder)
-	certConfig["ca_file"] = fmt.Sprintf("%s/ca.crt", folder)
+	certConfig["ca_file"] = fmt.Sprintf("%s/ca-bundle.crt", folder)
 
 	(*exporter)["tls"] = certConfig
 }
 
-func configureExporterEndpoint(exporter *map[interface{}]interface{}, cm corev1.ConfigMap) error {
+func configureExporterEndpoint(exporter map[string]interface{}, cm corev1.ConfigMap) error {
 	url := cm.Data["endpoint"]
 	if url == "" {
 		return kverrors.New("no value for 'endpoint' in configmap", "name", cm.Name)
 	}
-	(*exporter)["endpoint"] = url
+	exporter["endpoint"] = url
 	return nil
 }

--- a/internal/tracing/manifests/otelcol/exporter_test.go
+++ b/internal/tracing/manifests/otelcol/exporter_test.go
@@ -98,7 +98,7 @@ func Test_ConfigureExportersEndpoints(t *testing.T) {
 	exportersField = cfg["exporters"]
 	exporters = exportersField.(map[string]interface{})
 	otlphttpField := exporters["otlphttp"]
-	otlphttp := otlphttpField.(map[interface{}]interface{})
+	otlphttp := otlphttpField.(map[string]interface{})
 	require.NotNil(t, otlphttp["endpoint"])
 }
 
@@ -136,7 +136,7 @@ func Test_configureExporterSecrets(t *testing.T) {
 }
 
 func Test_configureExporterEndpoint(t *testing.T) {
-	exporter := make(map[interface{}]interface{})
+	exporter := make(map[string]interface{})
 	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tracing-auth",
@@ -150,7 +150,7 @@ func Test_configureExporterEndpoint(t *testing.T) {
 		},
 	}
 
-	err := configureExporterEndpoint(&exporter, cm)
+	err := configureExporterEndpoint(exporter, cm)
 	require.NoError(t, err)
 
 	require.NotNil(t, exporter["endpoint"])
@@ -168,6 +168,6 @@ func Test_configureExporterEndpoint(t *testing.T) {
 		},
 	}
 
-	err = configureExporterEndpoint(&exporter, cm)
+	err = configureExporterEndpoint(exporter, cm)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Previously, we relied on the user to extract the CA used by the OTELCol in the Hub and store it in a ConfigMap. Now, we get it directly from the secret.

Also, this PR fixes a runtime crash.