### PR TITLE
Fix TLS for tracing signal

### DIFF
--- a/demo/addon-config/charts/tracing/templates/tracing-auth-configmap.yaml
+++ b/demo/addon-config/charts/tracing/templates/tracing-auth-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     mcoa.openshift.io/signal: tracing
 data:
-  nothing: mTLS
+  otlp: mTLS
 {{- end }}

--- a/demo/addon-install/templates/managed-cluster-addon.yaml
+++ b/demo/addon-install/templates/managed-cluster-addon.yaml
@@ -39,5 +39,13 @@ spec:
   - resource: opentelemetrycollectors
     name: spoke-otelcol
     namespace: multicluster-observability-addon
+  # Tracing Auth ConfigMap
+  - resource: configmaps
+    name: tracing-auth
+    namespace: open-cluster-management
+  # Tracing ca-bundle configmap
+  - resource: secrets
+    name: otel-gateway
+    namespace: observability
 {{- end }}
 {{- end }}

--- a/demo/addon-install/templates/tracing-endpoint-configmap.yaml
+++ b/demo/addon-install/templates/tracing-endpoint-configmap.yaml
@@ -10,6 +10,6 @@ metadata:
   annotations:
     tracing.mcoa.openshift.io/target-output-name: otlp
 data:
-  endpoint: test-collector-observability.apps.{{ $.Values.hubClusterName }}:80
+  endpoint: otlp-grpc-otel-gateway-route-observability.apps.{{ $.Values.hubClusterName }}:443
 {{- end }}
 {{- end }}

--- a/demo/mcoa-demo/templates/placement-binding-hub-cluster.yaml
+++ b/demo/mcoa-demo/templates/placement-binding-hub-cluster.yaml
@@ -31,3 +31,6 @@ subjects:
   - name: policy-grafana-jobs
     kind: Policy
     apiGroup: policy.open-cluster-management.io
+  - name: policy-otel-jobs
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io

--- a/demo/mcoa-demo/templates/policy-hub-otel-jobs.yaml
+++ b/demo/mcoa-demo/templates/policy-hub-otel-jobs.yaml
@@ -1,0 +1,89 @@
+{{- if and .Values.tracing.enabled }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-otel-jobs
+spec:
+  disabled: false
+  policy-templates:
+  - extraDependencies:
+    - apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: ConfigurationPolicy
+      name: redhat-otel-operator
+    objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: annotate-otel-ca
+      spec:
+        remediationAction: enforce
+        severity: high
+        pruneObjectBehavior: DeleteAll
+        object-templates:
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: batch/v1
+            kind: Job
+            metadata:
+              name: annotate-ca
+              namespace: observability
+            spec:
+              template:
+                spec:
+                  serviceAccountName: annotate-ca-job-sa
+                  containers:
+                  - name: annotate-ca
+                    image: bitnami/kubectl
+                    command:
+                      - "/bin/sh"
+                      - "-c"
+                      - |
+                        while true; do
+                          while true; do
+                            if kubectl get secret/otel-gateway -n observability >/dev/null 2>&1; then
+                              kubectl -n observability label --overwrite secret/otel-gateway mcoa.openshift.io/signal=tracing
+                              kubectl -n observability annotate --overwrite secret/otel-gateway tracing.mcoa.openshift.io/ca=true
+                              break
+                            else
+                              echo "Waiting for Secret..."
+                              sleep 10
+                            fi
+                          done
+                          sleep 10
+                        done
+                  restartPolicy: Never
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              name: annotate-ca-job-sa
+              namespace: observability
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: annotate-ca-job-role
+              namespace: observability
+            rules:
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get", "patch", "update"]
+        - complianceType: musthave
+          objectDefinition:
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: annotate-ca-job-role-binding
+              namespace: observability
+            subjects:
+            - kind: ServiceAccount
+              name: annotate-ca-job-sa
+              namespace: observability
+            roleRef:
+              kind: Role
+              name: annotate-ca-job-role
+              apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/demo/mcoa-demo/templates/policy-hub-otel.yaml
+++ b/demo/mcoa-demo/templates/policy-hub-otel.yaml
@@ -212,20 +212,4 @@ spec:
 {{- range $_, $cluster_name := .Values.spokeClusters }}
                           - otlp/{{ $cluster_name }}
 {{- end }}
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: route.openshift.io/v1
-              kind: Route
-              metadata:
-                name: test-collector
-                namespace: observability
-              spec:
-                host: test-collector-observability.apps.{{ .Values.hubClusterName }}
-                port:
-                  targetPort: otlp-grpc
-                to:
-                  kind: Service
-                  name: otel-gateway-collector
-                  weight: 100
-                wildcardPolicy: None
 {{- end }}

--- a/demo/mcoa-demo/templates/policy-hub-otel.yaml
+++ b/demo/mcoa-demo/templates/policy-hub-otel.yaml
@@ -165,7 +165,15 @@ spec:
                     otlp:
                       protocols:
                         http:
+                          tls:
+                            cert_file: /certs/tls.crt
+                            key_file: /certs/tls.key
+                            ca_file: /certs/ca.crt
                         grpc:
+                          tls:
+                            cert_file: /certs/tls.crt
+                            key_file: /certs/tls.key
+                            ca_file: /certs/ca.crt
                   exporters:
                     debug/default:
                     debug/cluster1:

--- a/internal/tracing/manifests/otelcol/exporter.go
+++ b/internal/tracing/manifests/otelcol/exporter.go
@@ -22,15 +22,15 @@ func ConfigureExportersSecrets(cfg map[string]interface{}, secret corev1.Secret,
 		if otelExporterName != exporterName {
 			continue
 		}
-		var configMap map[interface{}]interface{}
+		var configMap map[string]interface{}
 		if config == nil {
-			configMap = make(map[interface{}]interface{})
+			configMap = make(map[string]interface{})
 			exporters[otelExporterName] = configMap
 		} else {
-			configMap = config.(map[interface{}]interface{})
+			configMap = config.(map[string]interface{})
 		}
 
-		configureExporterSecrets(&configMap, secret)
+		configureExporterSecrets(configMap, secret)
 
 	}
 	return nil
@@ -79,7 +79,7 @@ func getExporters(cfg map[string]interface{}) (map[string]interface{}, error) {
 	return exporters, nil
 }
 
-func configureExporterSecrets(exporter *map[interface{}]interface{}, secret corev1.Secret) {
+func configureExporterSecrets(exporter map[string]interface{}, secret corev1.Secret) {
 	certConfig := make(map[string]interface{})
 	folder := fmt.Sprintf("/%s", secret.Name)
 	certConfig["insecure"] = false
@@ -87,7 +87,7 @@ func configureExporterSecrets(exporter *map[interface{}]interface{}, secret core
 	certConfig["key_file"] = fmt.Sprintf("%s/tls.key", folder)
 	certConfig["ca_file"] = fmt.Sprintf("%s/ca-bundle.crt", folder)
 
-	(*exporter)["tls"] = certConfig
+	exporter["tls"] = certConfig
 }
 
 func configureExporterEndpoint(exporter map[string]interface{}, cm corev1.ConfigMap) error {

--- a/internal/tracing/manifests/otelcol/exporter_test.go
+++ b/internal/tracing/manifests/otelcol/exporter_test.go
@@ -52,7 +52,7 @@ func Test_ConfigureExportersSecrets(t *testing.T) {
 	exportersField = cfg["exporters"]
 	exporters = exportersField.(map[string]interface{})
 	otlphttpField := exporters["otlphttp"]
-	otlphttp := otlphttpField.(map[interface{}]interface{})
+	otlphttp := otlphttpField.(map[string]interface{})
 	require.NotNil(t, otlphttp["tls"])
 }
 
@@ -119,7 +119,7 @@ func Test_getExporters(t *testing.T) {
 }
 
 func Test_configureExporterSecrets(t *testing.T) {
-	exporter := make(map[interface{}]interface{})
+	exporter := make(map[string]interface{})
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tracing-otlphttp-auth",
@@ -131,7 +131,7 @@ func Test_configureExporterSecrets(t *testing.T) {
 			"tls.key": []byte("data"),
 		},
 	}
-	configureExporterSecrets(&exporter, secret)
+	configureExporterSecrets(exporter, secret)
 	require.NotNil(t, exporter["tls"])
 }
 


### PR DESCRIPTION
After noticing there were some issues with the routing processor + the OTLP HTTP receiver, I switched to OTLP GRPC. But there were some problems with the route and we disabled TLS for tracing.

This PR fixes the issues with TLS and GRPC and enables it back.