### PR TITLE
addon: Remove restartPolicy from metrics-addon-agent deployment

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/deployment.yaml
@@ -51,7 +51,6 @@ spec:
               cpu: 1
               memory: 1Gi
           imagePullPolicy: IfNotPresent
-          restartPolicy: Always
           securityContext: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File


### PR DESCRIPTION
After implementing health checking in the addon, it reports that the deployment `metrics-addon-agent` fails with the following message:

```
'Failed to apply manifest: Deployment.apps "metrics-addon-agent"
          is invalid: spec.template.spec.containers[0].restartPolicy: Forbidden: may
          not be set for non-init containers'
```
Removing `spec.template.spec.containers[0].restartPolicy` solves this issue.
