### PR TITLE
Add management support for the multicluster-observability-operator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ spec:
   - name: userWorkloadLogsCollection
     value: clusterlogforwarders.v1.logging.openshift.io
   - name: userWorkloadTracesCollection
-    value: opentelemetrycollectors.v1alpha1.opentelemetry.io
+    value: opentelemetrycollectors.v1beta1.opentelemetry.io
   - name: userWorkloadInstrumentation
     value: instrumentations.v1alpha1.opentelemetry.io
 ``` 
@@ -96,7 +96,7 @@ spec:
 Supported keys are:
 - `platformLogsCollection`: Supports values `clusterlogforwarders.v1.logging.openshift.io`
 - `userWorkloadLogsCollection`: Supports values `clusterlogforwarders.v1.logging.openshift.io`
-- `userWorkloadTracesCollection`: Supports values `opentelemetrycollectors.v1alpha1.opentelemetry.io`
+- `userWorkloadTracesCollection`: Supports values `opentelemetrycollectors.v1beta1.opentelemetry.io`
 - `userWorkloadTracesInstrumentation`: Supports values `instrumentations.v1alpha1.opentelemetry.io`
 
 __Note__: Some keys can hold multiple values separated by semicolon to support multiple data collection capabilities in parallel, e.g:
@@ -111,7 +111,7 @@ spec:
   customizedVariables:
   # User Workloads Observability with multiple collectors
   - name: userWorkloadLogsCollection
-    value: clusterlogforwarders.v1.logging.openshift.io;opentelemetrycollectors.v1alpha1.opentelemetry.io
+    value: clusterlogforwarders.v1.logging.openshift.io;opentelemetrycollectors.v1beta1.opentelemetry.io
 ```
 
 The addon installation is managed by the addon-manager. This means that users
@@ -142,15 +142,6 @@ for the `serviceAccountName` field that's set by MCOA.
 This MCOA supports all outputs defined in [OpenShift Documentation](https://docs.openshift.com/container-platform/latest/observability/logging/log_collection_forwarding/configuring-log-forwarding.html)([API Ref](https://github.com/openshift/cluster-logging-operator/blob/master/api/logging/v1/output_types.go#L22-L43)). Furthermore, since MCOA will simply ship the specified secrets together with `ClusterLogForwarder` MCOA is also able to support all authentication methods supported by `ClusterLogForwarder`.
 
 Note: the service account used by the `ClusterLogForwarder` deployed by MCOA is `openshift-logging/mcoa-logcollector`, this information is esential when using the AWS STS authentication.
-
-### Configuring User Workloads Observability Capabilities
-
-#### Logs Collection
-
-Currently the addon supports configuration to send logs either to:
-
-- CloudWatch: requires the auth configmap to be specified
-- Loki: requires the auth configmap, the url configmap and optionally the inject ca configmap
 
 ### Traces Collection
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Currently the addon supports configuration to send logs either to:
 - CloudWatch: requires the auth configmap to be specified
 - Loki: requires the auth configmap, the url configmap and optionally the inject ca configmap
 
-### Traces Collection & Instrumentation 
+### Traces Collection
 
 Currently MCOA supports deploying a single instance of `OpenTelemetryCollector`
 templated with the stanza created in the hub cluster. The instance deployed in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,20 @@ Supported keys are:
 - `userWorkloadTracesCollection`: Supports values `opentelemetrycollectors.v1alpha1.opentelemetry.io`
 - `userWorkloadTracesInstrumentation`: Supports values `instrumentations.v1alpha1.opentelemetry.io`
 
-__Note__: Keys can hold multiple values separated by semicolon, e.g. `clusterlogforwarders.v1.logging.openshift.io;opentelemetrycollectors.v1alpha1.opentelemetry.io`.
+__Note__: Some keys can hold multiple values separated by semicolon to support multiple data collection capabilities in parallel, e.g:
+
+```yaml
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: multicluster-observability-addon
+  namespace: open-cluster-management-observability
+spec:
+  customizedVariables:
+  # User Workloads Observability with multiple collectors
+  - name: userWorkloadLogsCollection
+    value: clusterlogforwarders.v1.logging.openshift.io;opentelemetrycollectors.v1alpha1.opentelemetry.io
+```
 
 The addon installation is managed by the addon-manager. This means that users
 don't need to explicetelly create resources to install the addon on spoke

--- a/demo/addon-config/charts/logging/templates/clusterlogforwarder.yaml
+++ b/demo/addon-config/charts/logging/templates/clusterlogforwarder.yaml
@@ -2,7 +2,7 @@ apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 spec:
   outputs:
 {{- range $_, $dic := .Values.outputs }}

--- a/demo/addon-config/charts/logging/templates/logging-auth-configmap.yaml
+++ b/demo/addon-config/charts/logging/templates/logging-auth-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: logging-auth
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
   labels:
     mcoa.openshift.io/signal: logging
 data:

--- a/demo/addon-config/charts/tracing/templates/otel-collector.yaml
+++ b/demo/addon-config/charts/tracing/templates/otel-collector.yaml
@@ -2,7 +2,7 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
   name: spoke-otelcol
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 spec:
   config: |
     receivers:

--- a/demo/addon-config/charts/tracing/templates/tracing-auth-configmap.yaml
+++ b/demo/addon-config/charts/tracing/templates/tracing-auth-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tracing-auth
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
   labels:
     mcoa.openshift.io/signal: tracing
 data:

--- a/demo/addon-install/templates/managed-cluster-addon.yaml
+++ b/demo/addon-install/templates/managed-cluster-addon.yaml
@@ -11,7 +11,7 @@ spec:
   # Logging Auth ConfigMap
   - resource: configmaps
     name: logging-auth
-    namespace: open-cluster-management
+    namespace: open-cluster-management-observability
   # Logging URLs for Loki ConfigMap
 {{- range $_, $dic := $.Values.logging.outputs }}
 {{- if eq $dic.type "loki" }}
@@ -38,7 +38,7 @@ spec:
   # Tracing Auth ConfigMap
   - resource: configmaps
     name: tracing-auth
-    namespace: open-cluster-management
+    namespace: open-cluster-management-observability
   # Tracing ca-bundle configmap
   - resource: secrets
     name: otel-gateway

--- a/demo/mcoa-demo/templates/logging-static-auth.yaml
+++ b/demo/mcoa-demo/templates/logging-static-auth.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: static-authentication
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 data:
   aws_access_key_id: {{ .Values.logging.aws.keyID | b64enc }}
   aws_secret_access_key: {{ .Values.logging.aws.keySecret | b64enc }} 

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -3,7 +3,7 @@ images:
   newName: quay.io/rhobs/multicluster-observability-addon
   newTag: v0.0.1
 
-namespace: open-cluster-management
+namespace: open-cluster-management-observability
 
 resources:
 - resources/cluster_role_binding.yaml

--- a/deploy/resources/addondeploymentconfig.yaml
+++ b/deploy/resources/addondeploymentconfig.yaml
@@ -2,7 +2,7 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: AddOnDeploymentConfig
 metadata:
   name: multicluster-observability-addon
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 spec:
   customizedVariables:
   # Operator Subscription Channels

--- a/deploy/resources/addondeploymentconfig.yaml
+++ b/deploy/resources/addondeploymentconfig.yaml
@@ -5,5 +5,16 @@ metadata:
   namespace: open-cluster-management
 spec:
   customizedVariables:
-    - name: loggingSubscriptionChannel
-      value: stable-5.9
+  # Operator Subscription Channels
+  - name: openshiftLoggingChannel
+    value: stable-5.9
+  # Platform Observability
+  - name: platformLogsCollection
+    value: clusterlogforwarders.v1.logging.openshift.io
+  # User Workloads Observability
+  - name: userWorkloadLogsCollection
+    value: clusterlogforwarders.v1.logging.openshift.io
+  - name: userWorkloadTracesCollection
+    value: opentelemetrycollectors.v1beta1.opentelemetry.io
+  - name: userWorkloadInstrumentation
+    value: instrumentations.v1alpha1.opentelemetry.io

--- a/deploy/resources/cluster-management-addon.yaml
+++ b/deploy/resources/cluster-management-addon.yaml
@@ -16,7 +16,7 @@ spec:
       resource: addondeploymentconfigs
       defaultConfig:
         name: multicluster-observability-addon
-        namespace: open-cluster-management
+        namespace: open-cluster-management-observability
     # Describes the default log forwarding outputs for each log type applied to all managed clusters.
     - group: logging.openshift.io
       resource: clusterlogforwarders
@@ -32,8 +32,8 @@ spec:
           - group: logging.openshift.io
             resource: clusterlogforwarders
             name: instance
-            namespace: open-cluster-management
+            namespace: open-cluster-management-observability
           - group: opentelemetry.io
             resource: opentelemetrycollectors
             name: instance
-            namespace: open-cluster-management
+            namespace: open-cluster-management-observability

--- a/hack/addon-install/templates/aws-secret-default.yaml
+++ b/hack/addon-install/templates/aws-secret-default.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-credentials-default
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 type: Opaque
 data:
   aws_access_key_id: {{ .Values.awsCredentials.accessKeyID | b64enc }}

--- a/hack/addon-install/templates/clf-instance.yaml
+++ b/hack/addon-install/templates/clf-instance.yaml
@@ -2,7 +2,7 @@ apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 spec:
   outputs:
    - cloudwatch:

--- a/hack/addon-install/templates/instance-default.yaml
+++ b/hack/addon-install/templates/instance-default.yaml
@@ -2,7 +2,7 @@ apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance-default
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 spec:
   outputs:
    - cloudwatch:

--- a/hack/addon-install/templates/otelcol-instance.yaml
+++ b/hack/addon-install/templates/otelcol-instance.yaml
@@ -2,7 +2,7 @@ apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: instance
-  namespace: open-cluster-management
+  namespace: open-cluster-management-observability
 spec:
   config:
     exporters:

--- a/internal/addon/helm/values.go
+++ b/internal/addon/helm/values.go
@@ -51,7 +51,7 @@ func GetValuesFunc(ctx context.Context, k8s client.Client) addonfactory.GetValue
 		}
 
 		if opts.Platform.Logs.CollectionEnabled || opts.UserWorkloads.Logs.CollectionEnabled {
-			loggingOpts, err := lhandlers.BuildOptions(ctx, k8s, mcAddon, opts.Platform.Logs, opts.Platform.Logs)
+			loggingOpts, err := lhandlers.BuildOptions(ctx, k8s, mcAddon, opts.Platform.Logs, opts.UserWorkloads.Logs)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/addon/helm/values.go
+++ b/internal/addon/helm/values.go
@@ -2,14 +2,12 @@ package helm
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/rhobs/multicluster-observability-addon/internal/addon"
 	lhandlers "github.com/rhobs/multicluster-observability-addon/internal/logging/handlers"
 	lmanifests "github.com/rhobs/multicluster-observability-addon/internal/logging/manifests"
 	thandlers "github.com/rhobs/multicluster-observability-addon/internal/tracing/handlers"
 	tmanifests "github.com/rhobs/multicluster-observability-addon/internal/tracing/manifests"
-	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -25,36 +23,35 @@ type HelmChartValues struct {
 	Tracing tmanifests.TracingValues `json:"tracing"`
 }
 
-type Options struct {
-	LoggingDisabled bool
-	TracingDisabled bool
-}
-
 func GetValuesFunc(ctx context.Context, k8s client.Client) addonfactory.GetValuesFunc {
 	return func(
 		cluster *clusterv1.ManagedCluster,
-		addon *addonapiv1alpha1.ManagedClusterAddOn,
+		mcAddon *addonapiv1alpha1.ManagedClusterAddOn,
 	) (addonfactory.Values, error) {
 		// if hub cluster, then don't install anything
 		if isHubCluster(cluster) {
 			return addonfactory.JsonStructToValues(HelmChartValues{})
 		}
 
-		aodc, err := getAddOnDeploymentConfig(ctx, k8s, addon)
+		aodc, err := getAddOnDeploymentConfig(ctx, k8s, mcAddon)
 		if err != nil {
 			return nil, err
 		}
-		opts, err := buildOptions(aodc)
+		opts, err := addon.BuildOptions(aodc)
 		if err != nil {
 			return nil, err
+		}
+
+		if !opts.Platform.Enabled && !opts.UserWorkloads.Enabled {
+			return addonfactory.JsonStructToValues(HelmChartValues{})
 		}
 
 		userValues := HelmChartValues{
 			Enabled: true,
 		}
 
-		if !opts.LoggingDisabled {
-			loggingOpts, err := lhandlers.BuildOptions(ctx, k8s, addon, aodc)
+		if opts.Platform.Logs.CollectionEnabled || opts.UserWorkloads.Logs.CollectionEnabled {
+			loggingOpts, err := lhandlers.BuildOptions(ctx, k8s, mcAddon, opts.Platform.Logs, opts.Platform.Logs)
 			if err != nil {
 				return nil, err
 			}
@@ -66,9 +63,8 @@ func GetValuesFunc(ctx context.Context, k8s client.Client) addonfactory.GetValue
 			userValues.Logging = *logging
 		}
 
-		if !opts.TracingDisabled {
-			klog.Info("Tracing enabled")
-			tracingOpts, err := thandlers.BuildOptions(ctx, k8s, addon, aodc)
+		if opts.UserWorkloads.Traces.CollectionEnabled {
+			tracingOpts, err := thandlers.BuildOptions(ctx, k8s, mcAddon, opts.UserWorkloads.Traces)
 			if err != nil {
 				return nil, err
 			}
@@ -92,35 +88,6 @@ func getAddOnDeploymentConfig(ctx context.Context, k8s client.Client, mcAddon *a
 		return addOnDeployment, err
 	}
 	return addOnDeployment, nil
-}
-
-func buildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Options, error) {
-	var opts Options
-	if addOnDeployment == nil {
-		return opts, nil
-	}
-
-	if addOnDeployment.Spec.CustomizedVariables == nil {
-		return opts, nil
-	}
-
-	for _, keyvalue := range addOnDeployment.Spec.CustomizedVariables {
-		switch keyvalue.Name {
-		case addon.AdcLoggingDisabledKey:
-			value, err := strconv.ParseBool(keyvalue.Value)
-			if err != nil {
-				return opts, err
-			}
-			opts.LoggingDisabled = value
-		case addon.AdcTracingisabledKey:
-			value, err := strconv.ParseBool(keyvalue.Value)
-			if err != nil {
-				return opts, err
-			}
-			opts.TracingDisabled = value
-		}
-	}
-	return opts, nil
 }
 
 func isHubCluster(cluster *clusterv1.ManagedCluster) bool {

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -47,7 +47,7 @@ func Test_Mcoa_Disable_Charts(t *testing.T) {
 				Resource: "addondeploymentconfigs",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "multicluster-observability-addon",
 			},
 		},
@@ -56,7 +56,7 @@ func Test_Mcoa_Disable_Charts(t *testing.T) {
 	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multicluster-observability-addon",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
 			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{},
@@ -111,19 +111,10 @@ func Test_Mcoa_Disable_Chart_Hub(t *testing.T) {
 	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multicluster-observability-addon",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
-			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-				{
-					Name:  "loggingDisabled",
-					Value: "true",
-				},
-				{
-					Name:  "tracingDisabled",
-					Value: "true",
-				},
-			},
+			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{},
 		},
 	}
 

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	loggingapis "github.com/openshift/cluster-logging-operator/apis"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
@@ -23,7 +22,6 @@ import (
 )
 
 var (
-	_ = loggingapis.AddToScheme(scheme.Scheme)
 	_ = operatorsv1.AddToScheme(scheme.Scheme)
 	_ = operatorsv1alpha1.AddToScheme(scheme.Scheme)
 	_ = addonapiv1alpha1.AddToScheme(scheme.Scheme)
@@ -114,7 +112,12 @@ func Test_Mcoa_Disable_Chart_Hub(t *testing.T) {
 			Namespace: "open-cluster-management-observability",
 		},
 		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
-			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{},
+			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+				{
+					Name:  addon.KeyPlatformLogsCollection,
+					Value: string(addon.ClusterLogForwarderV1),
+				},
+			},
 		},
 	}
 
@@ -134,5 +137,5 @@ func Test_Mcoa_Disable_Chart_Hub(t *testing.T) {
 
 	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(objects))
+	require.Empty(t, objects)
 }

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -59,16 +59,7 @@ func Test_Mcoa_Disable_Charts(t *testing.T) {
 			Namespace: "open-cluster-management",
 		},
 		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
-			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-				{
-					Name:  "loggingDisabled",
-					Value: "true",
-				},
-				{
-					Name:  "tracingDisabled",
-					Value: "true",
-				},
-			},
+			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{},
 		},
 	}
 
@@ -77,7 +68,7 @@ func Test_Mcoa_Disable_Charts(t *testing.T) {
 		WithObjects(addOnDeploymentConfig).
 		Build()
 
-	loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, addon.McoaChartDir).
+	agentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, addon.McoaChartDir).
 		WithGetValuesFuncs(GetValuesFunc(context.TODO(), fakeKubeClient)).
 		WithAgentRegistrationOption(&agent.RegistrationOption{}).
 		WithScheme(scheme.Scheme).
@@ -86,9 +77,9 @@ func Test_Mcoa_Disable_Charts(t *testing.T) {
 		klog.Fatalf("failed to build agent %v", err)
 	}
 
-	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
+	objects, err := agentAddon.Manifests(managedCluster, managedClusterAddOn)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(objects))
+	require.Empty(t, objects)
 }
 
 func Test_Mcoa_Disable_Chart_Hub(t *testing.T) {

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -12,9 +12,9 @@ const (
 	KeyPlatformLogsCollection = "platformLogsCollection"
 
 	// User Workloads Observability Keys
-	KeyUserWorkloadLogsCollection        = "userWorkloadLogsCollection"
-	KeyUserWorkloadTracesCollection      = "userWorkloadTracesCollection"
-	KeyUserWorkloadTracesInstrumentation = "userWorkloadTracesInstrumentation"
+	KeyUserWorkloadLogsCollection   = "userWorkloadLogsCollection"
+	KeyUserWorkloadTracesCollection = "userWorkloadTracesCollection"
+	KeyUserWorkloadInstrumentation  = "userWorkloadInstrumentation"
 )
 
 type CollectionKind string
@@ -90,7 +90,7 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 				opts.UserWorkloads.Enabled = true
 				opts.UserWorkloads.Traces.CollectionEnabled = true
 			}
-		case KeyUserWorkloadTracesInstrumentation:
+		case KeyUserWorkloadInstrumentation:
 			if keyvalue.Value == string(InstrumentationV1alpha1) {
 				opts.UserWorkloads.Enabled = true
 				opts.UserWorkloads.Traces.InstrumentationEnabled = true

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -1,0 +1,101 @@
+package addon
+
+import (
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+const (
+	// Operator Subscription Channels
+	KeyOpenShiftLoggingChannel = "openshiftLoggingChannel"
+
+	// Platform Observability Keys
+	KeyPlatformLogsCollection = "platformLogsCollection"
+
+	// User Workloads Observability Keys
+	KeyUserWorkloadLogsCollection        = "userWorkloadLogsCollection"
+	KeyUserWorkloadTracesCollection      = "userWorkloadTracesCollection"
+	KeyUserWorkloadTracesInstrumentation = "userWorkloadTracesInstrumentation"
+)
+
+type CollectionKind string
+
+const (
+	ClusterLogForwarderV1         CollectionKind = "clusterlogforwarders.v1.logging.openshift.io"
+	OpenTelemetryCollectorV1beta1 CollectionKind = "opentelemetrycollectors.v1beta1.opentelemetry.io"
+)
+
+type InstrumentationKind string
+
+const (
+	InstrumentationV1alpha1 InstrumentationKind = "instrumentations.v1alpha1.opentelemetry.io"
+)
+
+type LogsOptions struct {
+	CollectionEnabled   bool
+	SubscriptionChannel string
+}
+
+type TracesOptions struct {
+	CollectionEnabled      bool
+	InstrumentationEnabled bool
+	SubscriptionChannel    string
+}
+
+type PlatformOptions struct {
+	Enabled bool
+	Logs    LogsOptions
+}
+
+type UserWorkloadOptions struct {
+	Enabled bool
+	Logs    LogsOptions
+	Traces  TracesOptions
+}
+
+type Options struct {
+	Platform      PlatformOptions
+	UserWorkloads UserWorkloadOptions
+}
+
+func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Options, error) {
+	var opts Options
+	if addOnDeployment == nil {
+		return opts, nil
+	}
+
+	if addOnDeployment.Spec.CustomizedVariables == nil {
+		return opts, nil
+	}
+
+	for _, keyvalue := range addOnDeployment.Spec.CustomizedVariables {
+		switch keyvalue.Name {
+		// Operator Subscriptions
+		case KeyOpenShiftLoggingChannel:
+			opts.Platform.Logs.SubscriptionChannel = keyvalue.Value
+			opts.UserWorkloads.Logs.SubscriptionChannel = keyvalue.Value
+		// Platform Observability Options
+		case KeyPlatformLogsCollection:
+			if keyvalue.Value == string(ClusterLogForwarderV1) {
+				opts.Platform.Enabled = true
+				opts.Platform.Logs.CollectionEnabled = true
+			}
+		// User Workload Observability Options
+		case KeyUserWorkloadLogsCollection:
+			if keyvalue.Value == string(ClusterLogForwarderV1) {
+				opts.UserWorkloads.Enabled = true
+				opts.UserWorkloads.Logs.CollectionEnabled = true
+			}
+		case KeyUserWorkloadTracesCollection:
+			if keyvalue.Value == string(OpenTelemetryCollectorV1beta1) {
+				opts.UserWorkloads.Enabled = true
+				opts.UserWorkloads.Traces.CollectionEnabled = true
+			}
+		case KeyUserWorkloadTracesInstrumentation:
+			if keyvalue.Value == string(InstrumentationV1alpha1) {
+				opts.UserWorkloads.Enabled = true
+				opts.UserWorkloads.Traces.InstrumentationEnabled = true
+			}
+		}
+	}
+	return opts, nil
+}

--- a/internal/addon/var.go
+++ b/internal/addon/var.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	Name             = "multicluster-observability-addon"
-	InstallNamespace = "open-cluster-management"
+	InstallNamespace = "open-cluster-management-observability"
 
 	McoaChartDir    = "manifests/charts/mcoa"
 	LoggingChartDir = "manifests/charts/mcoa/charts/logging"

--- a/internal/addon/var.go
+++ b/internal/addon/var.go
@@ -13,15 +13,11 @@ const (
 	TracingChartDir = "manifests/charts/mcoa/charts/tracing"
 
 	AddonDeploymentConfigResource = "addondeploymentconfigs"
-
-	AdcLoggingDisabledKey = "loggingDisabled"
-	AdcTracingisabledKey  = "tracingDisabled"
-
-	ClusterLogForwardersResource = "clusterlogforwarders"
-	SpokeCLFName                 = "mcoa-instance"
-	SpokeCLFNamespace            = "openshift-logging"
-	clfProbeKey                  = "isReady"
-	clfProbePath                 = ".status.conditions[?(@.type==\"Ready\")].status"
+	ClusterLogForwardersResource  = "clusterlogforwarders"
+	SpokeCLFName                  = "mcoa-instance"
+	SpokeCLFNamespace             = "openshift-logging"
+	clfProbeKey                   = "isReady"
+	clfProbePath                  = ".status.conditions[?(@.type==\"Ready\")].status"
 
 	OpenTelemetryCollectorsResource = "opentelemetrycollectors"
 	SpokeOTELColName                = "mcoa-instance"

--- a/internal/logging/helm_test.go
+++ b/internal/logging/helm_test.go
@@ -36,10 +36,10 @@ var (
 
 func fakeGetValues(k8s client.Client) addonfactory.GetValuesFunc {
 	return func(
-		cluster *clusterv1.ManagedCluster,
-		addon *addonapiv1alpha1.ManagedClusterAddOn,
+		_ *clusterv1.ManagedCluster,
+		mcAddon *addonapiv1alpha1.ManagedClusterAddOn,
 	) (addonfactory.Values, error) {
-		opts, err := handlers.BuildOptions(context.TODO(), k8s, addon, nil)
+		opts, err := handlers.BuildOptions(context.TODO(), k8s, mcAddon, addon.LogsOptions{}, addon.LogsOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/logging/helm_test.go
+++ b/internal/logging/helm_test.go
@@ -81,7 +81,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 				Resource: "addondeploymentconfigs",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "multicluster-observability-addon",
 			},
 		},
@@ -91,7 +91,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 				Resource: "clusterlogforwarders",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "mcoa-instance",
 			},
 		},
@@ -101,7 +101,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 	clf = &loggingv1.ClusterLogForwarder{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mcoa-instance",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: loggingv1.ClusterLogForwarderSpec{
 			Inputs: []loggingv1.InputSpec{
@@ -162,7 +162,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 	staticCred = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "static-authentication",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Data: map[string][]byte{
 			"key":  []byte("data"),
@@ -173,7 +173,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multicluster-observability-addon",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
 			CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{

--- a/internal/logging/manifests/logging.go
+++ b/internal/logging/manifests/logging.go
@@ -2,22 +2,21 @@ package manifests
 
 import (
 	"encoding/json"
+	"errors"
 	"slices"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/rhobs/multicluster-observability-addon/internal/addon"
 )
 
-func buildSubscriptionChannel(resources Options) string {
-	adoc := resources.AddOnDeploymentConfig
-	if adoc == nil || len(adoc.Spec.CustomizedVariables) == 0 {
-		return defaultLoggingVersion
-	}
+var (
+	errPlatformLogsNotDefined     = errors.New("Platform logs not defined")
+	errUserWorkloadLogsNotDefined = errors.New("User Workloads logs not defined")
+)
 
-	for _, keyvalue := range adoc.Spec.CustomizedVariables {
-		if keyvalue.Name == subscriptionChannelValueKey {
-			return keyvalue.Value
-		}
+func buildSubscriptionChannel(resources Options) string {
+	if resources.SubscriptionChannel != "" {
+		return resources.SubscriptionChannel
 	}
 	return defaultLoggingVersion
 }
@@ -46,9 +45,38 @@ func buildSecrets(resources Options) ([]SecretValue, error) {
 	return secretsValue, nil
 }
 
-func buildClusterLogForwarderSpec(resources Options) (*loggingv1.ClusterLogForwarderSpec, error) {
-	clf := resources.ClusterLogForwarder
+func buildClusterLogForwarderSpec(opts Options) (*loggingv1.ClusterLogForwarderSpec, error) {
+	clf := opts.ClusterLogForwarder
 	clf.Spec.ServiceAccountName = "mcoa-logcollector"
+
+	// Validate Platform Logs enabled
+	var (
+		platformDetected      bool
+		userWorkloadsDetected bool
+	)
+	for _, pipeline := range clf.Spec.Pipelines {
+		// Consider pipelines without outputs invalid
+		if pipeline.OutputRefs == nil {
+			continue
+		}
+
+		for _, ref := range pipeline.InputRefs {
+			if ref == loggingv1.InputNameInfrastructure || ref == loggingv1.InputNameAudit {
+				platformDetected = true
+			}
+			if ref == loggingv1.InputNameApplication {
+				userWorkloadsDetected = true
+			}
+		}
+	}
+
+	if opts.Platform.CollectionEnabled && !platformDetected {
+		return nil, errPlatformLogsNotDefined
+	}
+
+	if opts.UserWorkloads.CollectionEnabled && !userWorkloadsDetected {
+		return nil, errUserWorkloadLogsNotDefined
+	}
 
 	return &clf.Spec, nil
 }

--- a/internal/logging/manifests/logging_test.go
+++ b/internal/logging/manifests/logging_test.go
@@ -101,7 +101,7 @@ func Test_BuildCLFSpec(t *testing.T) {
 				Resource: "clusterlogforwarders",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "mcoa-instance",
 			},
 		},
@@ -111,7 +111,7 @@ func Test_BuildCLFSpec(t *testing.T) {
 	clf = &loggingv1.ClusterLogForwarder{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mcoa-instance",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: loggingv1.ClusterLogForwarderSpec{
 			Inputs: []loggingv1.InputSpec{

--- a/internal/logging/manifests/logging_test.go
+++ b/internal/logging/manifests/logging_test.go
@@ -22,31 +22,19 @@ func Test_BuildSubscriptionChannel(t *testing.T) {
 		subChannel string
 	}{
 		{
-			name:       "unknown key",
-			key:        "test",
-			value:      "stable-1.0",
+			name:       "not set",
 			subChannel: "stable-5.9",
 		},
 		{
-			name:       "known key",
-			key:        "loggingSubscriptionChannel",
+			name:       "user set",
 			value:      "stable-5.7",
 			subChannel: "stable-5.7",
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			adoc := &addonapiv1alpha1.AddOnDeploymentConfig{
-				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
-					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-						{
-							Name:  tc.key,
-							Value: tc.value,
-						},
-					},
-				},
-			}
 			resources := Options{
-				AddOnDeploymentConfig: adoc,
+				SubscriptionChannel: tc.value,
 			}
 			subChannel := buildSubscriptionChannel(resources)
 			require.Equal(t, tc.subChannel, subChannel)

--- a/internal/logging/manifests/options.go
+++ b/internal/logging/manifests/options.go
@@ -4,11 +4,12 @@ import (
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/rhobs/multicluster-observability-addon/internal/addon"
 	corev1 "k8s.io/api/core/v1"
-	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 )
 
 type Options struct {
-	Secrets               map[addon.Endpoint]corev1.Secret
-	ClusterLogForwarder   *loggingv1.ClusterLogForwarder
-	AddOnDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig
+	Secrets             map[addon.Endpoint]corev1.Secret
+	ClusterLogForwarder *loggingv1.ClusterLogForwarder
+	Platform            addon.LogsOptions
+	UserWorkloads       addon.LogsOptions
+	SubscriptionChannel string
 }

--- a/internal/tracing/helm_test.go
+++ b/internal/tracing/helm_test.go
@@ -77,7 +77,7 @@ func Test_Tracing_AllConfigsTogether_AllResources(t *testing.T) {
 				Resource: "configmaps",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "tracing-auth",
 			},
 		},
@@ -89,7 +89,7 @@ func Test_Tracing_AllConfigsTogether_AllResources(t *testing.T) {
 				Resource: "addondeploymentconfigs",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "multicluster-observability-addon",
 			},
 		},
@@ -99,7 +99,7 @@ func Test_Tracing_AllConfigsTogether_AllResources(t *testing.T) {
 				Resource: "opentelemetrycollectors",
 			},
 			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
+				Namespace: "open-cluster-management-observability",
 				Name:      "mcoa-instance",
 			},
 		},
@@ -109,7 +109,7 @@ func Test_Tracing_AllConfigsTogether_AllResources(t *testing.T) {
 	otelCol := otelv1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mcoa-instance",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: otelv1beta1.OpenTelemetryCollectorSpec{
 			Config: otelv1beta1.Config{
@@ -130,7 +130,7 @@ func Test_Tracing_AllConfigsTogether_AllResources(t *testing.T) {
 	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multicluster-observability-addon",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{},
 	}
@@ -138,7 +138,7 @@ func Test_Tracing_AllConfigsTogether_AllResources(t *testing.T) {
 	authCM = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tracing-auth",
-			Namespace: "open-cluster-management",
+			Namespace: "open-cluster-management-observability",
 		},
 		Data: map[string]string{
 			"otlphttp": "mTLS",

--- a/internal/tracing/helm_test.go
+++ b/internal/tracing/helm_test.go
@@ -34,9 +34,9 @@ var (
 func fakeGetValues(k8s client.Client) addonfactory.GetValuesFunc {
 	return func(
 		cluster *clusterv1.ManagedCluster,
-		addon *addonapiv1alpha1.ManagedClusterAddOn,
+		mcAddon *addonapiv1alpha1.ManagedClusterAddOn,
 	) (addonfactory.Values, error) {
-		opts, err := handlers.BuildOptions(context.TODO(), k8s, addon, nil)
+		opts, err := handlers.BuildOptions(context.TODO(), k8s, mcAddon, addon.TracesOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tracing/manifests/options.go
+++ b/internal/tracing/manifests/options.go
@@ -13,4 +13,5 @@ type Options struct {
 	ConfigMaps             []corev1.ConfigMap
 	OpenTelemetryCollector *otelv1beta1.OpenTelemetryCollector
 	AddOnDeploymentConfig  *addonapiv1alpha1.AddOnDeploymentConfig
+	UserWorkloads          addon.TracesOptions
 }


### PR DESCRIPTION
The following PR prepares the addon to be managed by the [multicluster-observability-operator](stolostron/multicluster-observability-operator/). Two major changes are implemented:
- Support the proposed platform/user-workloads observability capabilities as key-values in the `AddonDeploymentConfig`.
- Use as a default deployment namespace `open-cluster-management-observability`

Furthermore the proposed implementation adds validation support in the logging handler for:
- Validate that at least one `ClusterLogForwarder` pipeline includes `infrastructure`  and/or `audit` input reference when `platformLogsCollection` set.
- Validate that at least one `ClusterLogForwarder` pipeline includes `application` input reference when `userWorkloadLogsCollection` set.

The above implementations are not comprehensive but illustrative on how the capabilities defined in the `AddonDeploymentConfig` can be used within the addon.